### PR TITLE
Added custom lidar data provider

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,7 @@ yarn-error.log*
 
 # TypeScript build info
 *.tsbuildinfo
+
+AGENTS.md
+docs/**
+.vscode/**

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -689,10 +689,13 @@ Each `src/helios-*.ts` file has a clearly bounded responsibility:
   stacking). Output polygons are clipped Sutherland-Hodgman against
   the building visibility disc so cast shadows never extend past
   the rendered surroundings.
-* **helios-lidar.ts**, `LidarSource` interface + `LIDAR_SOURCES`
-  provider registry + `findLidarSource(lat, lon)` resolver. Adding
-  a country means dropping a new file under
-  `./helios-lidar/providers/`.
+* **helios-lidar.ts**, `LidarSource` interface + static public
+  `LIDAR_SOURCES` registry + `findLidarSource(lat, lon)` resolver,
+  plus the config-aware `resolveLidarSource(lat, lon, cfg)` seam used
+  by the engine. Public countries still register under
+  `./helios-lidar/providers/`; the generic local nDSM source is built
+  on demand from card config and conceptually prepended at resolution
+  time rather than registered globally.
 * **helios-lidar/helios-lidar-pipeline.ts**, the shared post-
   processing every provider routes through: classify cells above a
   height threshold (with optional circular crop), size-capped
@@ -710,6 +713,11 @@ Each `src/helios-*.ts` file has a clearly bounded responsibility:
   LiDAR support; its lazy-loaded codecs (pako, zstd, lerc, jpeg,
   lzw) are inlined into the single-file bundle by Vite
   `inlineDynamicImports`.
+* **helios-lidar/helios-lidar-local-ndsm.ts**, config-driven generic
+  local GeoTIFF provider. Consumes one browser-accessible precomputed
+  nDSM raster (height above ground in metres), normalises nodata /
+  non-finite / negative cells, and feeds the same shared pipeline as
+  the public providers. No region-specific runtime logic lives here.
 * **helios-lidar/providers/helios-lidar-fr.ts**, IGN LiDAR HD
   pipeline for metropolitan France + Corsica. One WMS round-trip
   on `IGNF_LIDAR-HD_MNH_*` (`image/x-bil;bits=32`), feeds the

--- a/README.md
+++ b/README.md
@@ -90,6 +90,12 @@ Every option below is editable visually:
 | `building-color` | hex | `#d2d2d7` | Base colour for every rendered building, modulated by sun altitude across the day. |
 | `shadows-enabled` | boolean | `true` | Master toggle for cast ground shadows. When `false`, no shadows are projected. When `true`, the source is picked automatically: a LiDAR provider when one covers the home (buildings AND vegetation), OpenFreeMap building footprints otherwise (buildings only). All shadows are clipped to the building visibility radius for consistency with the rendered surroundings. See [LiDAR coverage](#lidar-coverage). |
 | `lidar-precision` | `'low' \| 'medium' \| 'high'` | `'medium'` | LiDAR raster size when a provider covers the home. Higher = finer shadow contours but a bigger payload. `low` 256², `medium` 512², `high` 1024² (close to IGN native sampling). No effect out of coverage. |
+| `lidar-local-ndsm-enabled` | boolean | `false` | Master opt-in for the generic local nDSM GeoTIFF provider. When `true` **and** every other `lidar-local-ndsm-*` key below is set and valid, Helios reads height-above-ground from a user-supplied local raster before trying the public providers. Invalid config disables only the local provider and falls through cleanly. |
+| `lidar-local-ndsm-url` | string | – | Browser-reachable URL of a single-band Float32 GeoTIFF/COG containing height **above ground** in metres (nDSM = DSM − DTM, pre-computed offline). Same-origin `/local/...` paths are recommended; cross-origin hosting requires CORS. A bare-earth DEM/DTM is **not** sufficient. |
+| `lidar-local-ndsm-min-lat` | number (deg) | – | Southern edge of the raster's geographic extent in EPSG:4326. Used both for the cheap `covers(lat, lon)` gate and as the raster's geographic frame at runtime. |
+| `lidar-local-ndsm-max-lat` | number (deg) | – | Northern edge of the raster's geographic extent in EPSG:4326. Must satisfy `min-lat < max-lat`. |
+| `lidar-local-ndsm-min-lon` | number (deg) | – | Western edge of the raster's geographic extent in EPSG:4326. |
+| `lidar-local-ndsm-max-lon` | number (deg) | – | Eastern edge of the raster's geographic extent in EPSG:4326. Must satisfy `min-lon < max-lon`. |
 | `shadow-opacity` | 0–1 | `0.32` | Opacity of the cast ground shadows. |
 | `sun-color` | hex | `#EF9F27` | Sun disc + arc + timeline irradiance area. |
 | `cloud-color` | hex | `#5A8DC4` | On-ground disc + timeline cloud area. |
@@ -148,6 +154,108 @@ If your country publishes a usable LiDAR HD endpoint (raw float heights via WMS 
 
 Out of coverage the card still renders shadows from OpenFreeMap building footprints, so the visual works worldwide, the LiDAR layer is a precision upgrade where available.
 
+If your area is not covered by any of the public providers above but you have access to LiDAR data, you can prepare your own raster and point Helios at it directly , see [Local nDSM GeoTIFF provider](#local-ndsm-geotiff-provider) below.
+
+---
+
+## Local nDSM GeoTIFF provider
+
+When no public LiDAR provider covers your area, you can still get true LiDAR-grade shadows (buildings AND vegetation) by preparing a local **nDSM** raster yourself and pointing Helios at it. The provider is generic: it carries no region-specific logic and is selected only when explicitly enabled, fully configured, and covering your home.
+
+### What is an nDSM?
+
+An **nDSM** is a *normalised Digital Surface Model* , a raster where each cell holds the **height above local ground** in metres:
+
+```
+nDSM = DSM (highest returns: buildings + trees) − DTM (bare-earth ground)
+```
+
+A cell value of `8.5` means "an object 8.5 m tall sits at this location". That's exactly the input the shared shadow pipeline expects (same contract as IGN's MNH product used by the French provider).
+
+### Why a DEM/DTM is not enough
+
+A bare-earth **DEM** or **DTM** describes terrain only , buildings and vegetation are filtered out by construction. Feeding a DEM into this provider will produce no useful object shadows. You need an nDSM (or a DSM/DTM pair, processed offline into an nDSM) for shadow casting to work.
+
+### Required raster format
+
+| Property | Requirement |
+| :--- | :--- |
+| Semantics | Height above ground, in metres (an nDSM) |
+| Bands | Single band |
+| Numeric type | Float32 strongly preferred (other numeric types are coerced) |
+| Container | GeoTIFF or COG |
+| CRS | EPSG:4326 (geographic lat/lon). The file's own CRS tag is **not** validated at runtime; the configured bbox is taken as the raster's geographic frame |
+| Nodata | GeoTIFF `GDAL_NODATA` tag is honoured when present (matching cells are skipped). Cells with `NaN` or negative values are clamped to `0` (valid ground) |
+| Extent | A small local extract centred on your home is strongly preferred over a regional file (see [Performance](#performance-guidance)) |
+
+### Home Assistant hosting
+
+Same-origin hosting under Home Assistant's built-in `/local/` path is the simplest and most reliable option. With Home Assistant's default config, files dropped under `<config>/www/` become available at `https://<your-ha>/local/...`:
+
+```
+<config>/www/helios/my-area-ndsm.tif
+                        ↓
+https://<your-ha>/local/helios/my-area-ndsm.tif
+```
+
+Cross-origin hosting works too, but the server has to send CORS headers (`Access-Control-Allow-Origin`) Helios can read; if the browser blocks the fetch, the provider falls back silently.
+
+### YAML configuration
+
+All six keys are required for the provider to activate. If any one is missing or invalid, Helios logs a single console warning per session and falls back to the public-provider chain (and then to OpenFreeMap footprints).
+
+```yaml
+type: custom:helios-card
+lidar-local-ndsm-enabled: true
+lidar-local-ndsm-url: /local/helios/my-area-ndsm.tif
+# Geographic extent of the raster, in EPSG:4326 degrees.
+# Replace these placeholders with the bbox your file actually covers.
+lidar-local-ndsm-min-lat: -34.10
+lidar-local-ndsm-max-lat: -33.90
+lidar-local-ndsm-min-lon: 150.90
+lidar-local-ndsm-max-lon: 151.10
+```
+
+The bbox is used for two things: a cheap synchronous coverage check around your home, and the geographic frame the pipeline uses when consuming the raster. Both axes must satisfy `min < max` and lie inside legal EPSG:4326 ranges (`-90..90`, `-180..180`).
+
+### Fallback behaviour
+
+The local provider sits **first** in the resolution chain:
+
+1. **Local nDSM**, when enabled, valid, and its bbox includes the home.
+2. **Public country LiDAR providers** (IGN FR, EA UK, IGN ES, PDOK NL, Kartverket NO) , unchanged.
+3. **OpenFreeMap building footprints** , whenever no LiDAR provider yields features.
+
+Failure modes are soft. A bad URL, decode error, empty raster, CORS rejection, or any other fetch failure resolves to "no LiDAR features" and the engine drops through to the building-footprint mask. The rest of the card keeps rendering normally.
+
+You can confirm which source is active via `window.heliosStats()` in the browser console; the local provider reports id `local-ndsm`.
+
+### Performance guidance
+
+The current GeoTIFF helper fetches the whole file before decoding, so file size matters:
+
+- **Crop to a small local extract** , a few hundred metres around your home is enough; the building-visibility radius (default 100 m, max 1000 m) is the relevant scale.
+- **Match resolution to need** , 1 m cell pitch is plenty for card-scale shadows; finer than 50 cm rarely adds visible detail and inflates the file.
+- **Keep it under ~10 MB** as a rough target. Larger files work but slow the first paint and use more memory.
+- **COG is accepted** as a container, but Helios does not yet exploit HTTP-range reads, so a COG buys you GIS-tool interoperability rather than partial-fetch savings today.
+
+### Example preparation workflow (NSW, Australia via ELVIS)
+
+This is **one example** of how to produce a suitable nDSM from open LiDAR data. Helios does **not** integrate with [ELVIS](https://elevation.fsdf.org.au/) directly, does not bundle NSW data, and has no NSW-specific code. The same shape of workflow applies to any LiDAR point cloud you can legally use; ELVIS is just a convenient public source.
+
+1. **Discover coverage** , browse [ELVIS](https://elevation.fsdf.org.au/) for your area of interest and download a classified LiDAR **point cloud** tile (LAS/LAZ). A bare-earth DEM alone is not sufficient.
+2. **Build a DSM** from the highest returns (e.g. `lasgrid`, `pdal pipeline` with `writers.gdal` `output_type=max`, or QGIS/ArcGIS DSM tools). 1 m cell pitch is a good default.
+3. **Build a DTM** from ground-classified returns only (classification `2`).
+4. **Align** the two rasters to identical extent, resolution, and CRS.
+5. **Subtract** `nDSM = DSM − DTM` (e.g. `gdal_calc.py -A dsm.tif -B dtm.tif --outfile=ndsm.tif --calc="A-B"`).
+6. **Clamp negatives** to `0` and preserve nodata separately from valid ground (Helios will also do this defensively at runtime).
+7. **Reproject to EPSG:4326** if your source is in a projected CRS (e.g. MGA / UTM): `gdalwarp -t_srs EPSG:4326 ndsm.tif ndsm-4326.tif`.
+8. **Export as Float32 COG**: `gdal_translate ndsm-4326.tif ndsm-cog.tif -of COG -co COMPRESS=DEFLATE -co PREDICTOR=3 -ot Float32`.
+9. **Host it** under `<config>/www/helios/` and reference it from the YAML as `/local/helios/ndsm-cog.tif`.
+10. **Record the bbox** of the exported file (`gdalinfo ndsm-cog.tif` → `Corner Coordinates`) and put it into the four `lidar-local-ndsm-*-lat`/`-lon` keys.
+
+The same steps work for any provider's LiDAR (state agencies, USGS 3DEP, local councils, etc.) , the runtime feature is intentionally generic.
+
 ---
 
 ## Technical stack
@@ -185,6 +293,7 @@ Source layout:
 | `src/helios-lidar.ts`       | `LidarSource` interface + provider registry |
 | `src/helios-lidar/helios-lidar-pipeline.ts` | Shared height-raster → shadow-polygon pipeline (flood fill + convex hull) |
 | `src/helios-lidar/helios-lidar-geotiff.ts`  | Float32 GeoTIFF fetch + decode + DSM-DTM math helpers |
+| `src/helios-lidar/helios-lidar-local-ndsm.ts` | Generic local nDSM GeoTIFF provider (config-driven, see [Local nDSM GeoTIFF provider](#local-ndsm-geotiff-provider)) |
 | `src/helios-lidar/providers/` | One file per country (`helios-lidar-fr.ts`, `-uk`, `-es`, `-nl`, `-no`) |
 | `src/helios-sun.ts`         | Solar position + Haurwitz / Kasten-Czeplak math |
 | `src/helios-weather.ts`     | Open-Meteo multi-model fetch + cache |

--- a/dist/helios.js
+++ b/dist/helios.js
@@ -29675,6 +29675,70 @@ async function fetchFloat32GeoTiff(url, rasterSize, signal) {
   }
   return out;
 }
+async function fetchFloat32GeoTiffWithNoData(url, rasterSize, signal) {
+  let resp;
+  try {
+    resp = await fetch(url, { signal });
+  } catch (_2) {
+    return null;
+  }
+  if (!resp.ok) return null;
+  let buf;
+  try {
+    buf = await resp.arrayBuffer();
+  } catch (_2) {
+    return null;
+  }
+  if (buf.byteLength < 200) return null;
+  let tiff;
+  try {
+    tiff = await fromArrayBuffer(buf);
+  } catch (_2) {
+    return null;
+  }
+  let image;
+  try {
+    image = await tiff.getImage();
+  } catch (_2) {
+    return null;
+  }
+  let noData = null;
+  try {
+    const anyImg = image;
+    if (typeof anyImg.getGDALNoData === "function") {
+      const raw2 = anyImg.getGDALNoData();
+      noData = typeof raw2 === "number" && Number.isFinite(raw2) ? raw2 : null;
+    }
+  } catch (_2) {
+    noData = null;
+  }
+  let rasters;
+  try {
+    rasters = await image.readRasters({
+      width: rasterSize,
+      height: rasterSize,
+      interleave: false,
+      samples: [0]
+    });
+  } catch (_2) {
+    return null;
+  }
+  let band;
+  if (Array.isArray(rasters)) {
+    if (rasters.length === 0) return null;
+    band = rasters[0];
+  } else {
+    band = rasters;
+  }
+  let data;
+  if (band instanceof Float32Array) {
+    data = band;
+  } else {
+    data = new Float32Array(band.length);
+    for (let i2 = 0; i2 < band.length; i2++) data[i2] = band[i2];
+  }
+  return { data, noData };
+}
 function subtractRasters(dsm, dtm) {
   const N2 = Math.min(dsm.length, dtm.length);
   const out = new Float32Array(N2);
@@ -29927,6 +29991,62 @@ const norwayKartverketNhm = {
     });
   }
 };
+function normaliseLocalNdsmRaster(band, noData) {
+  const hasNoData = noData !== null && Number.isFinite(noData);
+  for (let i2 = 0; i2 < band.length; i2++) {
+    const v2 = band[i2];
+    if (hasNoData && v2 === noData) {
+      band[i2] = NaN;
+      continue;
+    }
+    if (!Number.isFinite(v2)) {
+      band[i2] = NaN;
+      continue;
+    }
+    if (v2 < 0) {
+      band[i2] = 0;
+      continue;
+    }
+  }
+  return band;
+}
+function createLocalNdsmSource(cfg) {
+  const { url, minLat, maxLat, minLon, maxLon } = cfg;
+  return {
+    id: "local-ndsm",
+    name: "Local nDSM GeoTIFF",
+    covers(lat, lon) {
+      return lat >= minLat && lat <= maxLat && lon >= minLon && lon <= maxLon;
+    },
+    async fetchShadowRegions(opts) {
+      const rasterSize = Math.min(
+        RASTER_DEFAULTS.maxRasterSize,
+        Math.max(RASTER_DEFAULTS.minRasterSize, Math.round(opts.rasterSize))
+      );
+      let band;
+      let noData;
+      try {
+        const r2 = await fetchFloat32GeoTiffWithNoData(url, rasterSize, opts.signal);
+        band = r2 ? r2.data : null;
+        noData = r2 ? r2.noData : null;
+      } catch (_2) {
+        return emptyResult();
+      }
+      if (!band || band.length < rasterSize * rasterSize) return emptyResult();
+      normaliseLocalNdsmRaster(band, noData);
+      return processHeightRaster(band, {
+        rasterSize,
+        minLat,
+        maxLat,
+        minLon,
+        maxLon,
+        homeLat: opts.homeLat,
+        homeLon: opts.homeLon,
+        cropRadiusMeters: opts.cropRadiusMeters
+      });
+    }
+  };
+}
 const LIDAR_SOURCES = [
   franceLidarHd,
   englandLidarComposite,
@@ -29939,6 +30059,51 @@ function findLidarSource(lat, lon) {
     if (src.covers(lat, lon)) return src;
   }
   return null;
+}
+function validateLocalNdsmConfig(cfg) {
+  if (!cfg) return null;
+  if (cfg["lidar-local-ndsm-enabled"] !== true) return null;
+  const rawUrl = cfg["lidar-local-ndsm-url"];
+  if (typeof rawUrl !== "string") return null;
+  const url = rawUrl.trim();
+  if (url.length === 0) return null;
+  const minLat = numFromCfg(cfg["lidar-local-ndsm-min-lat"]);
+  const maxLat = numFromCfg(cfg["lidar-local-ndsm-max-lat"]);
+  const minLon = numFromCfg(cfg["lidar-local-ndsm-min-lon"]);
+  const maxLon = numFromCfg(cfg["lidar-local-ndsm-max-lon"]);
+  if (minLat === null || maxLat === null || minLon === null || maxLon === null) return null;
+  if (minLat < -90 || minLat > 90 || maxLat < -90 || maxLat > 90) return null;
+  if (minLon < -180 || minLon > 180 || maxLon < -180 || maxLon > 180) return null;
+  if (!(minLat < maxLat)) return null;
+  if (!(minLon < maxLon)) return null;
+  return { url, minLat, maxLat, minLon, maxLon };
+}
+function numFromCfg(v2) {
+  if (typeof v2 === "number" && Number.isFinite(v2)) return v2;
+  if (typeof v2 === "string") {
+    const s2 = v2.trim();
+    if (s2.length === 0) return null;
+    const n3 = Number(s2);
+    return Number.isFinite(n3) ? n3 : null;
+  }
+  return null;
+}
+let _warnedInvalidLocalNdsm = false;
+function resolveLidarSource(lat, lon, cfg) {
+  const localCfg = validateLocalNdsmConfig(cfg);
+  if (cfg && cfg["lidar-local-ndsm-enabled"] === true && localCfg === null) {
+    if (!_warnedInvalidLocalNdsm) {
+      _warnedInvalidLocalNdsm = true;
+      console.warn(
+        "[HELIOS] lidar-local-ndsm-enabled is true but the local nDSM config is incomplete or invalid; falling back to public LiDAR providers and the OpenFreeMap building-footprint mask. Required keys: lidar-local-ndsm-url plus the four lidar-local-ndsm-{min,max}-{lat,lon} bbox values in EPSG:4326."
+      );
+    }
+  }
+  if (localCfg) {
+    const local = createLocalNdsmSource(localCfg);
+    if (local.covers(lat, lon)) return local;
+  }
+  return findLidarSource(lat, lon);
 }
 const DEFAULT_BUILDING_RADIUS_M = 100;
 const DEFAULT_BUILDING_OPACITY = 0.25;
@@ -30331,6 +30496,22 @@ const _HeliosEngine = class _HeliosEngine {
   //based on whether a LiDAR provider covers the home.
   _shadowsEnabled() {
     return this.cfg["shadows-enabled"] !== false;
+  }
+  //String fingerprint of the YAML-only local nDSM config surface.
+  //Used to invalidate the cached LiDAR shadow fetch when the user
+  //enables/disables the local provider or edits its URL / bbox.
+  //Raw values are stringified deliberately: the validator in
+  //helios-lidar.ts owns type/range coercion, while the engine only
+  //needs a stable "did anything relevant change?" signal.
+  _localNdsmConfigKey() {
+    return JSON.stringify([
+      this.cfg["lidar-local-ndsm-enabled"],
+      this.cfg["lidar-local-ndsm-url"],
+      this.cfg["lidar-local-ndsm-min-lat"],
+      this.cfg["lidar-local-ndsm-max-lat"],
+      this.cfg["lidar-local-ndsm-min-lon"],
+      this.cfg["lidar-local-ndsm-max-lon"]
+    ]);
   }
   _shadowOpacity() {
     const raw2 = Number(this.cfg["shadow-opacity"]);
@@ -31251,8 +31432,16 @@ const _HeliosEngine = class _HeliosEngine {
   //    MapTiler footprints (or to no shadows if disabled).
   _ensureLidarFetched() {
     if (!this.map) return;
-    const provider = findLidarSource(this.homeLat, this.homeLon);
-    if (!provider || !this._shadowsEnabled()) {
+    if (!this._shadowsEnabled()) {
+      this._lidarShadowFeatures = null;
+      this._lidarShadowDiagnostics = null;
+      this._lidarShadowKey = "";
+      this._lidarShadowAbort?.abort();
+      this._lidarShadowAbort = void 0;
+      return;
+    }
+    const provider = resolveLidarSource(this.homeLat, this.homeLon, this.cfg);
+    if (!provider) {
       this._lidarShadowFeatures = null;
       this._lidarShadowDiagnostics = null;
       this._lidarShadowKey = "";
@@ -32036,7 +32225,7 @@ const _HeliosEngine = class _HeliosEngine {
   //hemisphere is kept, the sun-arc orientation depends on it), and
   //the API key never leaves the card-level snapshot anyway.
   getStatsSnapshot() {
-    const provider = findLidarSource(this.homeLat, this.homeLon);
+    const provider = resolveLidarSource(this.homeLat, this.homeLon, this.cfg);
     const shadowsOn = this._shadowsEnabled();
     const lidarFeatures = this._lidarShadowFeatures;
     const buildingsFootprints = this._buildingsData ? {
@@ -32104,6 +32293,7 @@ const _HeliosEngine = class _HeliosEngine {
     const prevPrecision = this._lidarPrecisionLevel();
     const prevShadowOpa = this._shadowOpacity();
     const prevShadowsOn = this._shadowsEnabled();
+    const prevLocalNdsm = this._localNdsmConfigKey();
     this.cfg = { ...cfg };
     if (!this.map) {
       return;
@@ -32128,6 +32318,8 @@ const _HeliosEngine = class _HeliosEngine {
     const nextCluster = this._buildingClusterRadiusMeters();
     const nextOpacity = this._buildingOpacity();
     const nextColor = this._buildingColor();
+    const nextShadowsOn = this._shadowsEnabled();
+    const nextLocalNdsm = this._localNdsmConfigKey();
     if (nextRadius !== prevRadius || nextCluster !== prevCluster) {
       this._buildingsData = null;
       this._buildingsFetchKey = "";
@@ -32150,11 +32342,13 @@ const _HeliosEngine = class _HeliosEngine {
       }
     }
     const nextPrecision = this._lidarPrecisionLevel();
-    if (nextPrecision !== prevPrecision) {
+    if (nextPrecision !== prevPrecision || nextRadius !== prevRadius || nextLocalNdsm !== prevLocalNdsm) {
       this._lidarShadowKey = "";
       this._lidarShadowFeatures = null;
       this._lidarShadowDiagnostics = null;
-      this._ensureLidarFetched();
+      if (nextShadowsOn && nextShadowsOn === prevShadowsOn) {
+        this._ensureLidarFetched();
+      }
     }
     const nextShadowOpa = this._shadowOpacity();
     if (nextShadowOpa !== prevShadowOpa) {
@@ -32167,7 +32361,6 @@ const _HeliosEngine = class _HeliosEngine {
         }
       }
     }
-    const nextShadowsOn = this._shadowsEnabled();
     if (nextShadowsOn !== prevShadowsOn) {
       if (nextShadowsOn) {
         this._ensureLidarFetched();

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "helios",
-  "version": "1.5.0-beta.1",
+  "version": "1.5.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "helios",
-      "version": "1.5.0-beta.1",
+      "version": "1.5.0",
       "dependencies": {
         "@mapbox/vector-tile": "^2.0.4",
         "geotiff": "^3.0.5",

--- a/src/helios-engine.ts
+++ b/src/helios-engine.ts
@@ -4,7 +4,12 @@ import { getSunPosition, computePvPower, computeIrradianceWm2 } from './helios-s
 import { fetchHomePointData, RATE_LIMIT_BACKOFF_MS, type SampleHourly } from './helios-weather';
 import { fetchBuildingsAroundHome, type BuildingsResult } from './helios-buildings';
 import { projectExtrusionShadows } from './helios-shadows';
-import { findLidarSource } from './helios-lidar';
+import { findLidarSource, resolveLidarSource } from './helios-lidar';
+//findLidarSource is re-exported from this module so external callers
+//(stats helpers, future debug surfaces) that historically used the
+//configless probe keep working. The engine itself now uses
+//resolveLidarSource so the local-nDSM provider is honoured.
+void findLidarSource;
 
 //Public types
 
@@ -126,7 +131,46 @@ export interface HeliosConfig
     'lidar-precision'?:       unknown;
     //Opacity of the cast ground shadow layer, 0..1. Default 0.32.
     'shadow-opacity'?:         unknown;
+    //Optional generic local nDSM (normalised Digital Surface Model)
+    //GeoTIFF LiDAR provider. Lets a user point Helios at a single
+    //browser-accessible Float32 GeoTIFF/COG containing height above
+    //ground in metres, prepared offline. The provider is generic:
+    //it carries no region-specific behaviour and is selected only
+    //when explicitly enabled, fully configured, and covering the
+    //home. When unset or disabled, Helios falls back to the public
+    //provider chain and the OpenFreeMap building-footprint mask
+    //exactly as before.
+    //  lidar-local-ndsm-enabled : boolean, default false. Master
+    //                             opt-in for this provider.
+    //  lidar-local-ndsm-url     : string, optional. Browser-reachable
+    //                             URL of the nDSM GeoTIFF (same-origin
+    //                             /local/... is the recommended path).
+    //  lidar-local-ndsm-min-lat : number, optional. Southern edge of
+    //                             the raster's geographic extent in
+    //                             EPSG:4326 degrees.
+    //  lidar-local-ndsm-max-lat : number, optional. Northern edge.
+    //  lidar-local-ndsm-min-lon : number, optional. Western edge.
+    //  lidar-local-ndsm-max-lon : number, optional. Eastern edge.
+    //The four bbox keys describe the raster's geographic frame at
+    //runtime. They drive both the cheap covers(lat, lon) gate and
+    //the RasterGeo extent passed to processHeightRaster() once the
+    //file is decoded. Invalid or incomplete local-provider config
+    //disables only the local provider instance; the rest of the
+    //card config remains valid.
+    'lidar-local-ndsm-enabled'? : unknown;
+    'lidar-local-ndsm-url'?     : unknown;
+    'lidar-local-ndsm-min-lat'? : unknown;
+    'lidar-local-ndsm-max-lat'? : unknown;
+    'lidar-local-ndsm-min-lon'? : unknown;
+    'lidar-local-ndsm-max-lon'? : unknown;
 }
+
+//Default for the optional generic local nDSM LiDAR provider opt-in.
+//Exported so any future config-parsing or visual-editor code can use
+//the same fallback. All other local-nDSM keys are optional and have
+//no default; the provider is only considered configured when the
+//validator in helios-lidar.ts accepts every required field.
+export const DEFAULT_LIDAR_LOCAL_NDSM_ENABLED = false;
 
 //Default values for the building config, exposed so the visual
 //editor can render the matching placeholder / slider defaults.
@@ -1101,6 +1145,24 @@ export class HeliosEngine
     private _shadowsEnabled(): boolean
     {
         return this.cfg['shadows-enabled'] !== false;
+    }
+
+    //String fingerprint of the YAML-only local nDSM config surface.
+    //Used to invalidate the cached LiDAR shadow fetch when the user
+    //enables/disables the local provider or edits its URL / bbox.
+    //Raw values are stringified deliberately: the validator in
+    //helios-lidar.ts owns type/range coercion, while the engine only
+    //needs a stable "did anything relevant change?" signal.
+    private _localNdsmConfigKey(): string
+    {
+        return JSON.stringify([
+            this.cfg['lidar-local-ndsm-enabled'],
+            this.cfg['lidar-local-ndsm-url'],
+            this.cfg['lidar-local-ndsm-min-lat'],
+            this.cfg['lidar-local-ndsm-max-lat'],
+            this.cfg['lidar-local-ndsm-min-lon'],
+            this.cfg['lidar-local-ndsm-max-lon']
+        ]);
     }
 
     private _shadowOpacity(): number
@@ -2350,8 +2412,18 @@ export class HeliosEngine
     {
         if (!this.map) return;
 
-        const provider = findLidarSource(this.homeLat, this.homeLon);
-        if (!provider || !this._shadowsEnabled())
+        if (!this._shadowsEnabled())
+        {
+            this._lidarShadowFeatures    = null;
+            this._lidarShadowDiagnostics = null;
+            this._lidarShadowKey         = '';
+            this._lidarShadowAbort?.abort();
+            this._lidarShadowAbort       = undefined;
+            return;
+        }
+
+        const provider = resolveLidarSource(this.homeLat, this.homeLon, this.cfg);
+        if (!provider)
         {
             this._lidarShadowFeatures    = null;
             this._lidarShadowDiagnostics = null;
@@ -3623,7 +3695,7 @@ export class HeliosEngine
     //the API key never leaves the card-level snapshot anyway.
     public getStatsSnapshot(): Record<string, unknown>
     {
-        const provider = findLidarSource(this.homeLat, this.homeLon);
+        const provider = resolveLidarSource(this.homeLat, this.homeLon, this.cfg);
         const shadowsOn = this._shadowsEnabled();
         const lidarFeatures = this._lidarShadowFeatures;
         const buildingsFootprints = this._buildingsData
@@ -3703,6 +3775,7 @@ export class HeliosEngine
         const prevPrecision   = this._lidarPrecisionLevel();
         const prevShadowOpa   = this._shadowOpacity();
         const prevShadowsOn   = this._shadowsEnabled();
+        const prevLocalNdsm   = this._localNdsmConfigKey();
         this.cfg = { ...cfg };
 
         if (!this.map)
@@ -3744,6 +3817,8 @@ export class HeliosEngine
         const nextCluster = this._buildingClusterRadiusMeters();
         const nextOpacity = this._buildingOpacity();
         const nextColor   = this._buildingColor();
+        const nextShadowsOn = this._shadowsEnabled();
+        const nextLocalNdsm = this._localNdsmConfigKey();
         if (nextRadius !== prevRadius || nextCluster !== prevCluster)
         {
             this._buildingsData     = null;
@@ -3776,16 +3851,23 @@ export class HeliosEngine
             }
         }
 
-        //LiDAR precision change invalidates the cached shadow features
-        //(fetch key includes the raster size) and triggers a refetch
-        //at the new sampling. _ensureLidarFetched handles the diff.
+        //LiDAR fetch inputs that affect which source is selected or
+        //what raster area gets requested invalidate the cached shadow
+        //features and trigger a refetch when shadows stay enabled:
+        //precision, visible radius, and the YAML-only local nDSM
+        //config surface.
         const nextPrecision = this._lidarPrecisionLevel();
-        if (nextPrecision !== prevPrecision)
+        if (nextPrecision !== prevPrecision
+         || nextRadius !== prevRadius
+         || nextLocalNdsm !== prevLocalNdsm)
         {
             this._lidarShadowKey         = '';
             this._lidarShadowFeatures    = null;
             this._lidarShadowDiagnostics = null;
-            this._ensureLidarFetched();
+            if (nextShadowsOn && nextShadowsOn === prevShadowsOn)
+            {
+                this._ensureLidarFetched();
+            }
         }
 
         //Shadow opacity is a paint-level update on the raster layer.
@@ -3805,7 +3887,6 @@ export class HeliosEngine
         //Master shadow toggle: when turning on, fetch LiDAR shadows
         //if a provider covers the home; when turning off, drop the
         //cached LiDAR features and clear the projected polygons.
-        const nextShadowsOn = this._shadowsEnabled();
         if (nextShadowsOn !== prevShadowsOn)
         {
             if (nextShadowsOn)

--- a/src/helios-lidar.ts
+++ b/src/helios-lidar.ts
@@ -80,6 +80,11 @@ import { englandLidarComposite } from './helios-lidar/providers/helios-lidar-uk'
 import { spainPnoaLidar }       from './helios-lidar/providers/helios-lidar-es';
 import { netherlandsAhn4 }      from './helios-lidar/providers/helios-lidar-nl';
 import { norwayKartverketNhm }  from './helios-lidar/providers/helios-lidar-no';
+import {
+    createLocalNdsmSource,
+    type LocalNdsmConfig
+} from './helios-lidar/helios-lidar-local-ndsm';
+import type { HeliosConfig } from './helios-engine';
 
 //Registered providers, ordered by preference. The first provider
 //whose covers() probe accepts the home position wins. Bbox checks
@@ -102,4 +107,98 @@ export function findLidarSource(lat: number, lon: number): LidarSource | null
         if (src.covers(lat, lon)) return src;
     }
     return null;
+}
+
+//Read the six `lidar-local-ndsm-*` keys off a HeliosConfig and either
+//return a fully-typed LocalNdsmConfig (when every required field is
+//valid) or null (when the provider is disabled, the URL is missing,
+//or any bbox value is missing / non-finite / out of EPSG:4326 range /
+//ordered wrong). Never throws; invalid local-provider config never
+//invalidates the rest of the card config.
+export function validateLocalNdsmConfig(cfg: HeliosConfig | undefined | null): LocalNdsmConfig | null
+{
+    if (!cfg) return null;
+    if (cfg['lidar-local-ndsm-enabled'] !== true) return null;
+
+    const rawUrl = cfg['lidar-local-ndsm-url'];
+    if (typeof rawUrl !== 'string') return null;
+    const url = rawUrl.trim();
+    if (url.length === 0) return null;
+
+    const minLat = numFromCfg(cfg['lidar-local-ndsm-min-lat']);
+    const maxLat = numFromCfg(cfg['lidar-local-ndsm-max-lat']);
+    const minLon = numFromCfg(cfg['lidar-local-ndsm-min-lon']);
+    const maxLon = numFromCfg(cfg['lidar-local-ndsm-max-lon']);
+    if (minLat === null || maxLat === null || minLon === null || maxLon === null) return null;
+
+    if (minLat < -90 || minLat > 90 || maxLat < -90 || maxLat > 90) return null;
+    if (minLon < -180 || minLon > 180 || maxLon < -180 || maxLon > 180) return null;
+    if (!(minLat < maxLat)) return null;
+    if (!(minLon < maxLon)) return null;
+
+    return { url, minLat, maxLat, minLon, maxLon };
+}
+
+function numFromCfg(v: unknown): number | null
+{
+    if (typeof v === 'number' && Number.isFinite(v)) return v;
+    if (typeof v === 'string')
+    {
+        const s = v.trim();
+        if (s.length === 0) return null;
+        const n = Number(s);
+        return Number.isFinite(n) ? n : null;
+    }
+    return null;
+}
+
+//One-shot warning latch. When the user enables the local provider
+//but leaves the config incomplete or invalid, log exactly once per
+//session so the silent fall-through is diagnosable without spamming
+//the console on every shadow refresh.
+let _warnedInvalidLocalNdsm = false;
+
+//Config-aware provider resolver. Behaviour:
+//
+//  1. When the local-nDSM config validates, construct a per-config
+//     LocalNdsmSource and return it if it covers (lat, lon). This
+//     takes precedence over any public provider that would otherwise
+//     match the same point.
+//  2. Otherwise (no local config, or local config does not cover the
+//     point) fall back to the existing static LIDAR_SOURCES chain
+//     via findLidarSource().
+//
+//findLidarSource() and the static LIDAR_SOURCES list are unchanged
+//and still exported for any caller that does not need config-aware
+//resolution.
+export function resolveLidarSource(
+    lat: number,
+    lon: number,
+    cfg: HeliosConfig | undefined | null
+): LidarSource | null
+{
+    const localCfg = validateLocalNdsmConfig(cfg);
+
+    if (cfg && cfg['lidar-local-ndsm-enabled'] === true && localCfg === null)
+    {
+        if (!_warnedInvalidLocalNdsm)
+        {
+            _warnedInvalidLocalNdsm = true;
+            console.warn(
+                '[HELIOS] lidar-local-ndsm-enabled is true but the local nDSM '
+              + 'config is incomplete or invalid; falling back to public LiDAR '
+              + 'providers and the OpenFreeMap building-footprint mask. '
+              + 'Required keys: lidar-local-ndsm-url plus the four '
+              + 'lidar-local-ndsm-{min,max}-{lat,lon} bbox values in EPSG:4326.'
+            );
+        }
+    }
+
+    if (localCfg)
+    {
+        const local = createLocalNdsmSource(localCfg);
+        if (local.covers(lat, lon)) return local;
+    }
+
+    return findLidarSource(lat, lon);
 }

--- a/src/helios-lidar/helios-lidar-geotiff.ts
+++ b/src/helios-lidar/helios-lidar-geotiff.ts
@@ -103,6 +103,96 @@ export async function fetchFloat32GeoTiff(
     return out;
 }
 
+//Same byte path as fetchFloat32GeoTiff() but also returns the
+//GDAL_NODATA sentinel parsed from the GeoTIFF metadata (or null when
+//the tag is absent). Used by the local-nDSM provider so it can map
+//nodata cells to NaN before the shared pipeline runs; the public
+//providers stay on the simpler helper above and keep their existing
+//byte-for-byte behaviour.
+export async function fetchFloat32GeoTiffWithNoData(
+    url:        string,
+    rasterSize: number,
+    signal?:    AbortSignal
+): Promise<{ data: Float32Array; noData: number | null } | null>
+{
+    let resp: Response;
+    try
+    {
+        resp = await fetch(url, { signal });
+    }
+    catch (_)
+    {
+        return null;
+    }
+    if (!resp.ok) return null;
+
+    let buf: ArrayBuffer;
+    try { buf = await resp.arrayBuffer(); }
+    catch (_) { return null; }
+
+    if (buf.byteLength < 200) return null;
+
+    let tiff;
+    try { tiff = await fromArrayBuffer(buf); }
+    catch (_) { return null; }
+
+    let image;
+    try { image = await tiff.getImage(); }
+    catch (_) { return null; }
+
+    //getGDALNoData() returns the parsed GDAL_NODATA tag as a number,
+    //or null when the tag is absent. Some older geotiff.js versions
+    //expose it as a synchronous accessor; guard the call so a missing
+    //method does not break the fetch.
+    let noData: number | null = null;
+    try
+    {
+        const anyImg = image as unknown as { getGDALNoData?: () => number | null };
+        if (typeof anyImg.getGDALNoData === 'function')
+        {
+            const raw = anyImg.getGDALNoData();
+            noData = (typeof raw === 'number' && Number.isFinite(raw)) ? raw : null;
+        }
+    }
+    catch (_) { noData = null; }
+
+    let rasters;
+    try
+    {
+        rasters = await image.readRasters({
+            width:  rasterSize,
+            height: rasterSize,
+            interleave: false,
+            samples: [0]
+        });
+    }
+    catch (_) { return null; }
+
+    let band: ArrayLike<number>;
+    if (Array.isArray(rasters))
+    {
+        if (rasters.length === 0) return null;
+        band = rasters[0] as ArrayLike<number>;
+    }
+    else
+    {
+        band = rasters as unknown as ArrayLike<number>;
+    }
+
+    let data: Float32Array;
+    if (band instanceof Float32Array)
+    {
+        data = band;
+    }
+    else
+    {
+        data = new Float32Array(band.length);
+        for (let i = 0; i < band.length; i++) data[i] = band[i];
+    }
+
+    return { data, noData };
+}
+
 //Substract two equally-sized rasters element-wise (DSM minus DTM →
 //height-above-ground). NaN propagates through, so a no-data cell on
 //either input drops the corresponding output, which the pipeline then

--- a/src/helios-lidar/helios-lidar-local-ndsm.ts
+++ b/src/helios-lidar/helios-lidar-local-ndsm.ts
@@ -1,0 +1,132 @@
+//Generic local nDSM GeoTIFF / COG shadow source.
+//
+//Unlike the country-specific providers, this one is not registered in
+//the static LIDAR_SOURCES list. The engine builds it on demand from
+//the user's card config (via resolveLidarSource()) when, and only
+//when, every `lidar-local-ndsm-*` key in the config validates:
+//provider enabled, raster URL present, full EPSG:4326 bbox with
+//min < max on both axes and both axes inside legal ranges.
+//
+//The raster is interpreted as "height above ground in metres" (an
+//nDSM = DSM - DTM, prepared offline). A bare-earth DEM/DTM is not
+//valid input. Cells whose source value matches the file's
+//GDAL_NODATA tag are mapped to NaN so the shared pipeline skips
+//them; non-finite source values stay NaN; finite negatives are
+//clamped to 0 (valid ground); finite non-negatives pass through
+//unchanged.
+//
+//Decoding goes through fetchFloat32GeoTiffWithNoData(), which is a
+//thin extension of the existing fetchFloat32GeoTiff() that also
+//returns the parsed GDAL_NODATA sentinel from the GeoTIFF metadata
+//(or null when the tag is absent). The original helper is left
+//untouched so every existing provider keeps the exact same byte
+//path.
+
+import type {
+    LidarSource,
+    LidarShadowFetchOptions,
+    LidarShadowResult
+} from '../helios-lidar';
+import {
+    processHeightRaster,
+    emptyResult,
+    RASTER_DEFAULTS
+} from './helios-lidar-pipeline';
+import { fetchFloat32GeoTiffWithNoData } from './helios-lidar-geotiff';
+
+//Fully-validated local nDSM configuration. Produced by
+//validateLocalNdsmConfig() in helios-lidar.ts. The factory below
+//treats every field as already vetted (URL non-empty, bbox finite
+//and ordered, inside EPSG:4326 ranges).
+export interface LocalNdsmConfig
+{
+    url:    string;
+    minLat: number;
+    maxLat: number;
+    minLon: number;
+    maxLon: number;
+}
+
+//Normalise the resampled Float32Array in place. Exported so the
+//behaviour is verifiable from a unit-level test:
+//
+//  - source value == nodata sentinel        -> NaN
+//  - source value is NaN / +/-Infinity      -> NaN
+//  - finite negative                        -> 0 (valid ground)
+//  - finite non-negative                    -> unchanged
+//
+//Run exactly once on the resampled raster before processHeightRaster()
+//consumes it; resampling does not happen after normalisation.
+export function normaliseLocalNdsmRaster(
+    band:   Float32Array,
+    noData: number | null
+): Float32Array
+{
+    const hasNoData = noData !== null && Number.isFinite(noData);
+    for (let i = 0; i < band.length; i++)
+    {
+        const v = band[i];
+        if (hasNoData && v === noData)            { band[i] = NaN; continue; }
+        if (!Number.isFinite(v))                  { band[i] = NaN; continue; }
+        if (v < 0)                                { band[i] = 0;   continue; }
+        //finite, non-negative: leave untouched.
+    }
+    return band;
+}
+
+//Build a per-config LidarSource. Each call returns a fresh object so
+//multiple configs (today: at most one, but the seam is generic)
+//cannot share mutable state.
+export function createLocalNdsmSource(cfg: LocalNdsmConfig): LidarSource
+{
+    const { url, minLat, maxLat, minLon, maxLon } = cfg;
+
+    return {
+        id:   'local-ndsm',
+        name: 'Local nDSM GeoTIFF',
+
+        covers(lat: number, lon: number): boolean
+        {
+            return lat >= minLat && lat <= maxLat
+                && lon >= minLon && lon <= maxLon;
+        },
+
+        async fetchShadowRegions(opts: LidarShadowFetchOptions): Promise<LidarShadowResult>
+        {
+            //Clamp the requested raster size to the same bounds the
+            //pipeline uses for every other provider; the configured
+            //bbox is the geographic frame at runtime (the GeoTIFF is
+            //resampled to rasterSize x rasterSize regardless of its
+            //own georeferencing).
+            const rasterSize = Math.min(RASTER_DEFAULTS.maxRasterSize,
+                Math.max(RASTER_DEFAULTS.minRasterSize, Math.round(opts.rasterSize)));
+
+            let band: Float32Array | null;
+            let noData: number | null;
+            try
+            {
+                const r = await fetchFloat32GeoTiffWithNoData(url, rasterSize, opts.signal);
+                band   = r ? r.data   : null;
+                noData = r ? r.noData : null;
+            }
+            catch (_)
+            {
+                return emptyResult();
+            }
+            if (!band || band.length < rasterSize * rasterSize) return emptyResult();
+
+            normaliseLocalNdsmRaster(band, noData);
+
+            return processHeightRaster(band, {
+                rasterSize,
+                minLat,
+                maxLat,
+                minLon,
+                maxLon,
+                homeLat:          opts.homeLat,
+                homeLon:          opts.homeLon,
+                cropRadiusMeters: opts.cropRadiusMeters
+            });
+        }
+    };
+}


### PR DESCRIPTION
This allows you to bring your own high-res nDSM GeoTIFF for rendering the shadows. It's especially useful in cases where Helios' existing data providers don't have shadow data for your area.

I specifically did this for my own deployment using derived from LiDAR point cloud data provided by NSW, AU govt at https://elevation.fsdf.org.au/. This gives us calculated shadows from buildings, trees, fences etc.

This is the result for my area which has a large amount trees:
<img width="1055" height="713" alt="image" src="https://github.com/user-attachments/assets/cda8e501-4b00-439b-8f4e-beb9a3592cf6" />

As you can see the building shapes aren't there yet either - I'll look to allow for custom GeoJSON in a coming PR too.

You can use settings in the card yaml like the following:
```yaml
lidar-local-ndsm-enabled: true
lidar-local-ndsm-url: /local/community/Helios/lidar/nsw-home-ndsm-cog.tif
lidar-local-ndsm-min-lat: -33.xxxxxx
lidar-local-ndsm-max-lat: -33.xxxxxx
lidar-local-ndsm-min-lon: 151.xxxxxx
lidar-local-ndsm-max-lon: 151.xxxxxx
```

Also to be clear, I did use a combo of gpt-5.5 and opus 4.7 to build this out. Used a simple spec driven framework that I excluded from the repo to keep it clean. Happy to take any direction from you here. I've also got a collection of python tools  that help with processing the LiDAR data that I can add if useful.