### PR TITLE
Add home-latitude / home-longitude override

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,6 +103,8 @@ Every option below is editable visually:
 | `battery-color` | hex | `#FF5252` | Battery colour reused on both battery chips' borders + text + the static dotted leaders that connect each to the PV chip. |
 | `date-format` | string | `mm-dd` | Tokens: `yyyy`, `yy`, `mm`, `dd`. |
 | `time-format` | `'12h' \| '24h'` | `'24h'` | Clock display in the top-right chip. |
+| `home-latitude` | number | Home Assistant's home latitude | Optional override for the home latitude in decimal degrees. When BOTH `home-latitude` and `home-longitude` are set to valid coordinates, they take precedence over `hass.config.latitude` / `longitude` and the map recentres on the override. Useful when Home Assistant's configured home address isn't where you want the card centered (shared HA install, holiday home, mobile setup, privacy-conscious users who leave `hass.config` blank, or multiple cards on one dashboard each visualising a different place). Leave empty (default) to use HA's configured home. |
+| `home-longitude` | number | Home Assistant's home longitude | Optional override for the home longitude in decimal degrees. Only applied together with `home-latitude`; partial or out-of-range values are silently rejected and the card falls back to HA's configured home. |
 
 The PV entity picker filters to sensors that look like a power or energy reading (`device_class: power|energy` OR a unit in `W/kW/MW/Wh/kWh/MWh`). Both kinds work; the card auto-detects whether to display the entity's state directly (power sensor) or differentiate it on the fly (cumulative energy).
 

--- a/src/helios-card.ts
+++ b/src/helios-card.ts
@@ -439,8 +439,11 @@ export class HeliosCard extends LitElement
     //Diagnostic snapshot returned to `window.heliosStats()`. Includes
     //the live config, the engine state snapshot when the engine is
     //up, and a small PV block summarising the most recent history
-    //fetch outcome. JSON-safe, no DOM references, no PII (engine
-    //snapshot already strips the home lat/lon).
+    //fetch outcome. JSON-safe, no DOM references, no PII: the engine
+    //snapshot strips its own hass.config-sourced lat/lon, and the loop
+    //below additionally omits the `home-latitude` / `home-longitude`
+    //card-config override so user-supplied home coordinates never leak
+    //into the diagnostics output either.
     public getStatsSnapshot(): {
         config: Record<string, unknown>;
         engine: Record<string, unknown> | null;
@@ -452,6 +455,9 @@ export class HeliosCard extends LitElement
         {
             for (const [k, v] of Object.entries(this.config))
             {
+                //Skip user-supplied home coordinates so the snapshot
+                //stays PII-free, matching the engine-side stripping.
+                if (k === 'home-latitude' || k === 'home-longitude') continue;
                 cfg[k] = v;
             }
         }
@@ -473,17 +479,33 @@ export class HeliosCard extends LitElement
     //debug helpers. Clears the cached home key so the next `updated()`
     //pass sees `identityChanged` and re-inits the engine against the
     //new coordinates, then schedules a re-render to trigger that pass.
+    //
+    //The visual editor does NOT route through here when the user edits
+    //`home-latitude` / `home-longitude`: it dispatches `config-changed`,
+    //HA calls `setConfig()`, Lit re-renders, and `updated()` notices
+    //that `_getHomeCoords()` now resolves to a different key. The
+    //engine re-init falls out of that natural identity-drift path.
     public invalidateLocation(): void
     {
         this._lastHomeKey = '';
         this.requestUpdate();
     }
 
-    //Resolves the home coordinates. Reads the debug override on
-    //`window.__heliosLocationOverride` first (set via the global
-    //`setHeliosLocation` helper), then falls back to HA's configured
-    //home at hass.config.{latitude,longitude}. Returns null only when
-    //neither source has a usable pair.
+    //Resolves the home coordinates. Three-tier precedence, in order:
+    //  1. `window.__heliosLocationOverride` , the debug helper set via
+    //     the global `setHeliosLocation()` console function. Highest
+    //     priority so a developer can always force a location regardless
+    //     of card config.
+    //  2. The card config keys `home-latitude` / `home-longitude`.
+    //     Applied only when BOTH parse as numbers (or numeric strings)
+    //     that are finite and in valid range (lat -90..90, lon
+    //     -180..180). Anything else , including missing, partial, the
+    //     empty string, booleans or arrays which `Number()` would
+    //     happily coerce to 0 , is silently rejected so a half-edited
+    //     YAML never warps the card to {0,0}.
+    //  3. Home Assistant's configured home at
+    //     hass.config.{latitude,longitude}.
+    //Returns null only when none of the three has a usable pair.
     private _getHomeCoords(): { lat: number; lon: number } | null
     {
         const w = window as unknown as { __heliosLocationOverride?: { lat: number; lon: number } };
@@ -493,10 +515,43 @@ export class HeliosCard extends LitElement
         {
             return { lat: o.lat, lon: o.lon };
         }
+
+        const cfgLat = this._parseConfigCoord(this.config?.['home-latitude']);
+        const cfgLon = this._parseConfigCoord(this.config?.['home-longitude']);
+        if (cfgLat !== null && cfgLon !== null
+            && cfgLat >= -90  && cfgLat <= 90
+            && cfgLon >= -180 && cfgLon <= 180)
+        {
+            return { lat: cfgLat, lon: cfgLon };
+        }
+
         const lat = this.hass?.config?.latitude;
         const lon = this.hass?.config?.longitude;
         if (typeof lat !== 'number' || typeof lon !== 'number') return null;
         return { lat, lon };
+    }
+
+    //Defensive parser for `home-latitude` / `home-longitude` raw values
+    //coming out of the card config. The config is typed `unknown`, so
+    //bare `Number()` is unsafe: `Number('')`, `Number(false)`, `Number([])`,
+    //`Number(null)` all return 0, which is a finite, in-range latitude
+    //(Atlantic Ocean off the Gulf of Guinea) and would silently win the
+    //range check in `_getHomeCoords`. Accept numbers as-is and parse
+    //strings that look like a decimal number; reject everything else.
+    private _parseConfigCoord(raw: unknown): number | null
+    {
+        if (typeof raw === 'number')
+        {
+            return isFinite(raw) ? raw : null;
+        }
+        if (typeof raw === 'string')
+        {
+            const trimmed = raw.trim();
+            if (trimmed === '') return null;
+            const n = Number(trimmed);
+            return isFinite(n) ? n : null;
+        }
+        return null;
     }
 
     //Sizing for masonry view. 1 unit = 50 px so 12 ≈ 600 px.

--- a/src/helios-config.ts
+++ b/src/helios-config.ts
@@ -511,8 +511,47 @@ export class HeliosCardEditor extends LitElement
         const c = this._cfg;
         const t = this._t();
 
+        //Placeholders for the home lat/lon override fields. We surface
+        //HA's currently-configured home so the user instantly sees what
+        //they would be overriding, falling back to a neutral example
+        //(Amsterdam) when HA hasn't set one. Empty input means "use
+        //HA's home"; the placeholder is non-binding text only.
+        const haLat = this.hass?.config?.latitude;
+        const haLon = this.hass?.config?.longitude;
+        const latPlaceholder = typeof haLat === 'number' && isFinite(haLat)
+            ? String(haLat) : '52.379';
+        const lonPlaceholder = typeof haLon === 'number' && isFinite(haLon)
+            ? String(haLon) : '4.900';
+
         return html`
             <div class="editor">
+
+                <div class="section-title">${t.editor.locationSection}</div>
+                <label class="field">
+                    <span class="label">${t.editor.homeLatitude}</span>
+                    <input
+                        type="number"
+                        min="-90"
+                        max="90"
+                        step="any"
+                        placeholder="${latPlaceholder}"
+                        .value="${c['home-latitude'] != null ? String(c['home-latitude']) : ''}"
+                        @change="${(e: Event) => this._numField('home-latitude', e)}"
+                    />
+                </label>
+                <label class="field">
+                    <span class="label">${t.editor.homeLongitude}</span>
+                    <input
+                        type="number"
+                        min="-180"
+                        max="180"
+                        step="any"
+                        placeholder="${lonPlaceholder}"
+                        .value="${c['home-longitude'] != null ? String(c['home-longitude']) : ''}"
+                        @change="${(e: Event) => this._numField('home-longitude', e)}"
+                    />
+                </label>
+                <div class="hint">${t.editor.locationHint}</div>
 
                 <div class="section-title">${t.editor.mapSection}</div>
                 <label class="field">

--- a/src/helios-engine.ts
+++ b/src/helios-engine.ts
@@ -139,6 +139,16 @@ export interface HeliosConfig
     'lidar-precision'?:       unknown;
     //Opacity of the cast ground shadow layer, 0..1. Default 0.32.
     'shadow-opacity'?:         unknown;
+    //Optional override for the home location. When BOTH home-latitude
+    //(-90..90) and home-longitude (-180..180) parse as finite numbers
+    //in range, they are used as the home coordinates instead of
+    //hass.config.{latitude, longitude}. If either is missing, NaN, or
+    //out of range, both are ignored and the card falls back to HA's
+    //configured home. The window.__heliosLocationOverride debug helper
+    //still wins over this config (it stays the developer escape hatch
+    //for one-off testing from the browser console).
+    'home-latitude'?:          unknown;
+    'home-longitude'?:         unknown;
 }
 
 //Default values for the building config, exposed so the visual

--- a/src/i18n/index.ts
+++ b/src/i18n/index.ts
@@ -61,6 +61,14 @@ export interface Translations
 
     editor:
     {
+        //Optional override for the home location used as the card's
+        //center. When both fields are blank the card falls back to
+        //hass.config; when both are set to valid coords (lat -90..90,
+        //lon -180..180) they win over HA's configured home.
+        locationSection:          string;
+        homeLatitude:             string;
+        homeLongitude:            string;
+        locationHint:             string;
         mapSection:               string;
         mapStyle:                 string;
         mapStyleHint:             string;

--- a/src/i18n/locales/de.ts
+++ b/src/i18n/locales/de.ts
@@ -28,6 +28,10 @@ export const de: Translations = {
 
     editor:
     {
+        locationSection:    'Standort',
+        homeLatitude:       'Breitengrad des Zuhauses *',
+        homeLongitude:      'Längengrad des Zuhauses *',
+        locationHint:       'Überschreibt die Heimadresse, die als Mittelpunkt der Karte verwendet wird. Beide Felder leer lassen, um die in Home Assistant konfigurierte Adresse zu nutzen. Die Überschreibung wird nur angewendet, wenn BEIDE Felder gültige Koordinaten enthalten; unvollständige oder ungültige Werte werden ignoriert.',
         mapSection:         'Karte',
         mapStyle:           'Kartenstil *',
         mapStyleHint:       'Drei Basiskarten: Straßen (nüchtern, urban), Topo (Höhenlinien und Erdtöne, ideal in hügeligem Gelände) oder Minimal (lädt Straßen und entfernt anschließend alle überflüssigen Beschriftungen, POI-Symbole und Beschilderungen für eine flüssigere Darstellung). 3D-Gebäude und Beschriftungen verhalten sich auf Straßen und Topo identisch. Die dunkle Variante des gewählten Stils wird automatisch verwendet, wenn das Karten-Thema auf dunkel gesetzt ist.',

--- a/src/i18n/locales/en.ts
+++ b/src/i18n/locales/en.ts
@@ -38,6 +38,10 @@ export const en: Translations = {
 
     editor:
     {
+        locationSection:    'Location',
+        homeLatitude:       'Home latitude *',
+        homeLongitude:      'Home longitude *',
+        locationHint:       'Override the home address used as the card\'s center. Leave both fields empty to use Home Assistant\'s configured home. The override is only applied when BOTH fields are set to valid coordinates; partial or out-of-range values silently fall back to the HA default.',
         mapSection:         'Map',
         mapStyle:           'Map style *',
         mapStyleHint:       'Three basemaps: Streets (sober, urban), Topo (contour lines and earth tones, better in hilly terrain), or Minimal (loads Streets then strips every non-essential label, POI icon and road shield for a faster render). 3D buildings and labels behave identically on Streets and Topo. The dark variant of the chosen style is used automatically when the card theme is set to dark.',

--- a/src/i18n/locales/es.ts
+++ b/src/i18n/locales/es.ts
@@ -28,6 +28,10 @@ export const es: Translations = {
 
     editor:
     {
+        locationSection:    'Ubicación',
+        homeLatitude:       'Latitud del hogar *',
+        homeLongitude:      'Longitud del hogar *',
+        locationHint:       'Anula la dirección del hogar usada como centro de la tarjeta. Deja ambos campos vacíos para usar el hogar configurado en Home Assistant. La anulación se aplica solo cuando AMBOS campos contienen coordenadas válidas; los valores parciales o fuera de rango se ignoran silenciosamente.',
         mapSection:         'Mapa',
         mapStyle:           'Estilo del mapa *',
         mapStyleHint:       'Tres mapas base: Calles (sobrio, urbano), Topo (líneas de nivel y tonos terrosos, ideal en terreno montañoso) o Minimal (carga Calles y elimina todas las etiquetas, iconos POI y escudos viarios superfluos para un renderizado más rápido). Los edificios 3D y las etiquetas se comportan igual en Calles y Topo. La variante oscura del estilo elegido se usa automáticamente cuando el tema de la tarjeta está en oscuro.',

--- a/src/i18n/locales/fr.ts
+++ b/src/i18n/locales/fr.ts
@@ -36,6 +36,10 @@ export const fr: Translations = {
 
     editor:
     {
+        locationSection:    'Localisation',
+        homeLatitude:       'Latitude du domicile *',
+        homeLongitude:      'Longitude du domicile *',
+        locationHint:       'Remplace l\'adresse du domicile utilisée comme centre de la carte. Laissez les deux champs vides pour utiliser le domicile configuré dans Home Assistant. La substitution n\'est appliquée que lorsque LES DEUX champs contiennent des coordonnées valides ; toute valeur partielle ou hors plage est ignorée silencieusement.',
         mapSection:         'Carte',
         mapStyle:           'Style de la carte *',
         mapStyleHint:       'Trois fonds de carte : Rues (sobre, urbain), Topo (lignes de niveau et tons terreux, idéal en zone vallonnée) ou Minimal (charge le fond Rues puis retire tous les libellés, icônes POI et boucliers routiers superflus pour gagner en performance). Les bâtiments 3D et les libellés se comportent à l\'identique sur Rues et Topo. La variante sombre du style choisi est utilisée automatiquement quand le thème de la carte est en mode sombre.',

--- a/src/i18n/locales/it.ts
+++ b/src/i18n/locales/it.ts
@@ -28,6 +28,10 @@ export const it: Translations = {
 
     editor:
     {
+        locationSection:    'Posizione',
+        homeLatitude:       'Latitudine di casa *',
+        homeLongitude:      'Longitudine di casa *',
+        locationHint:       'Sovrascrive l\'indirizzo di casa usato come centro della scheda. Lascia entrambi i campi vuoti per usare l\'indirizzo configurato in Home Assistant. La sovrascrittura è applicata solo quando ENTRAMBI i campi contengono coordinate valide; valori parziali o fuori intervallo vengono ignorati silenziosamente.',
         mapSection:         'Mappa',
         mapStyle:           'Stile della mappa *',
         mapStyleHint:       'Tre mappe di base: Strade (sobria, urbana), Topo (curve di livello e toni terrosi, ideale in terreno collinare) o Minimal (carica Strade e rimuove tutte le etichette, icone POI e segnali stradali superflui per un rendering più rapido). Gli edifici 3D e le etichette si comportano allo stesso modo su Strade e Topo. La variante scura dello stile scelto viene usata automaticamente quando il tema della scheda è impostato su scuro.',

--- a/src/i18n/locales/nl.ts
+++ b/src/i18n/locales/nl.ts
@@ -28,6 +28,10 @@ export const nl: Translations = {
 
     editor:
     {
+        locationSection:    'Locatie',
+        homeLatitude:       'Breedtegraad woning *',
+        homeLongitude:      'Lengtegraad woning *',
+        locationHint:       'Overschrijft het thuisadres dat als middelpunt van de kaart wordt gebruikt. Laat beide velden leeg om het in Home Assistant geconfigureerde adres te gebruiken. De override geldt alleen wanneer BEIDE velden geldige coördinaten bevatten; gedeeltelijke of ongeldige waarden worden stilzwijgend genegeerd.',
         mapSection:         'Kaart',
         mapStyle:           'Kaartstijl *',
         mapStyleHint:       'Drie basiskaarten: Straten (sober, stedelijk), Topo (hoogtelijnen en aardse tinten, ideaal in heuvelachtig terrein) of Minimal (laadt Straten en verwijdert vervolgens alle overbodige labels, POI-iconen en wegbeschildering voor een vlotter renderen). 3D-gebouwen en labels gedragen zich identiek op Straten en Topo. De donkere variant van de gekozen stijl wordt automatisch gebruikt wanneer het kaartthema op donker staat.',

--- a/src/i18n/locales/no.ts
+++ b/src/i18n/locales/no.ts
@@ -37,6 +37,10 @@ export const no: Translations = {
 
     editor:
     {
+        locationSection:    'Sted',
+        homeLatitude:       'Hjemmets breddegrad *',
+        homeLongitude:      'Hjemmets lengdegrad *',
+        locationHint:       'Overstyrer hjemmeadressen som brukes som kortets sentrum. La begge feltene være tomme for å bruke hjemmet som er konfigurert i Home Assistant. Overstyringen brukes kun når BEGGE feltene har gyldige koordinater; ufullstendige eller ugyldige verdier ignoreres stille.',
         mapSection:         'Kart',
         mapStyle:           'Kartstil *',
         mapStyleHint:       'Tre grunnkart: Gater (nøkternt, urbant), Topo (høydekoter og jordfargetoner, bedre i kupert terreng) eller Minimal (laster Gater og fjerner alle ikke-essensielle etiketter, POI-ikoner og veiskilt for raskere rendering). 3D-bygninger og etiketter oppfører seg likt på Gater og Topo. Den mørke varianten av valgt stil brukes automatisk når korttemaet er satt til mørkt.',

--- a/src/i18n/locales/pt.ts
+++ b/src/i18n/locales/pt.ts
@@ -28,6 +28,10 @@ export const pt: Translations = {
 
     editor:
     {
+        locationSection:    'Localização',
+        homeLatitude:       'Latitude de casa *',
+        homeLongitude:      'Longitude de casa *',
+        locationHint:       'Substitui o endereço de casa usado como centro do cartão. Deixe ambos os campos vazios para usar o endereço configurado no Home Assistant. A substituição só é aplicada quando AMBOS os campos contêm coordenadas válidas; valores parciais ou fora do intervalo são ignorados silenciosamente.',
         mapSection:         'Mapa',
         mapStyle:           'Estilo do mapa *',
         mapStyleHint:       'Três mapas base: Ruas (sóbrio, urbano), Topo (curvas de nível e tons terrosos, ideal em terreno montanhoso) ou Minimal (carrega Ruas e remove todas as etiquetas, ícones POI e sinalética viária supérflua para um rendering mais rápido). Os edifícios 3D e as etiquetas comportam-se de forma idêntica em Ruas e Topo. A variante escura do estilo escolhido é usada automaticamente quando o tema do cartão está em escuro.',


### PR DESCRIPTION
## Summary

Adds two optional card config keys, `home-latitude` and `home-longitude`, that override `hass.config.{latitude, longitude}` when both parse as finite numbers in valid range. Useful when Home Assistant's configured home address isn't where you want the card centered: shared HA installs, holiday/parents' homes, mobile setups, multiple cards on one dashboard each visualising a different place, or privacy-conscious users who leave `hass.config` coarse or blank.

## Precedence

`_getHomeCoords` now resolves in three tiers, highest first:

1. `window.__heliosLocationOverride` — the existing developer escape hatch (`setHeliosLocation()` / `clearHeliosLocation()` console helpers), unchanged.
2. `home-latitude` + `home-longitude` from the card config — applied only when **both** parse as finite numbers in valid range (lat -90..90, lon -180..180).
3. `hass.config.{latitude, longitude}` — Home Assistant's configured home, the existing default.

Partial, missing, NaN, or out-of-range config values silently fall back to `hass.config` so a half-edited YAML never warps the card. A defensive parser (`_parseConfigCoord`) explicitly rejects empty strings, booleans, arrays, and other non-numeric types that bare `Number()` would coerce to `0` and silently treat as a valid (0,0) latitude/longitude.

## Editor

A new "Location" section sits at the top of the visual editor (location affects every overlay: sun, weather, buildings, shadows — feels right to put first). Two `type="number"` inputs reuse the existing `_numField` pattern (commit-on-blur), with `step="any"` to avoid Chrome silently clearing values typed with more decimal places than the step would allow. Placeholders display HA's currently configured `latitude` / `longitude` so the user instantly sees what the override would replace; leaving both empty falls back to HA's home, fully reversible.

## Diagnostics

`getStatsSnapshot()` filters the two new keys out of the config copy so that user-supplied home coordinates never leak into `window.heliosStats()`, preserving the existing no-PII guarantee that already strips `hass.config` lat/lon engine-side.

## i18n

Four new keys (`locationSection`, `homeLatitude`, `homeLongitude`, `locationHint`) added to the `Translations` interface and to all 8 locales (en, de, es, fr, it, nl, no, pt). Non-English translations are best-effort — happy to take corrections from native speakers in a follow-up.

## Docs

Two rows added to the README configuration table.

## Not included

- No version bump in `package.json` / `hacs.json` (left for the next release).
- No regenerated `dist/helios.js` — kept the diff source-only; rebuild on release.
- The internal data flow does not call `invalidateLocation()` from the editor; the engine reinits naturally via the existing `_lastHomeKey` identity-drift path inside `updated()`, identical to how any other identity input would work. Docstring updated to clarify this.

## Test plan

- [x] `npm run typecheck` — clean
- [x] `npm run build` — vite build succeeds
- [x] `npm test` — no failing tests (none defined)
- [ ] Manual: open the editor, confirm Location section appears at the top with two number inputs whose placeholders show HA's configured home.
- [ ] Manual: enter valid coords (e.g. 52.379 / 4.900), tab out, confirm the map recentres on Amsterdam, weather refreshes, buildings refetch.
- [ ] Manual: clear one field, confirm the map snaps back to HA's home.
- [ ] Manual: enter out-of-range latitude (e.g. 100), confirm the map stays on HA's home.
- [ ] Manual: with both fields set, run `setHeliosLocation(48.8566, 2.3522)` in console — confirm the debug helper wins; run `clearHeliosLocation()` — confirm it reverts to the configured override (not HA's home).
- [ ] Manual: `window.heliosStats()` should not contain `home-latitude` / `home-longitude` in the `config` block.
- [ ] Manual: switch HA UI language to one of the supported locales (e.g. fr) and confirm the new section renders translated labels.