### PR TITLE
Live power chips: two 0 W bug fixes, battery-centric chip sign, home consumption chip

### DIFF
--- a/src/card/battery.ts
+++ b/src/card/battery.ts
@@ -9,7 +9,7 @@ import { pvNormalizeToWatts } from './pv';
 import { callWSWithTimeout, WsTimeoutError } from './ws-timeout';
 import type { EnergyDefaults } from './energy-prefs';
 import { beginLoadingPhase, endLoadingPhase, type LoadingTrackerHost } from './loading-tracker';
-import { fetchChangeSeries, latestWattsFromChangeSeries, type ChangeBucket } from './energy-stats';
+import { fetchChangeSeries, latestWattsFromChangeSeries, changeRefreshAnchorMs, type ChangeBucket } from './energy-stats';
 
 
 //-----------------------------------------------------------------
@@ -315,8 +315,9 @@ export function refreshBattery(host: BatteryHost): void
 
 //Fetch the recorder `change` series for the battery charge (stat_energy_to) + discharge
 //(stat_energy_from) energy meters over the store's J-2 past window. Gated on a per-host fetch key
-//so it reissues only when the entity set or window changes. Charge and discharge are fetched as
-//two independent series so the consumer can net them with a structural sign.
+//that re-arms every CHANGE_REFRESH_MS (and on entity-set / window changes), so the series keeps
+//tracking newly committed recorder buckets during the session. Charge and discharge are fetched
+//as two independent series so the consumer can net them with a structural sign.
 function fetchBatteryChangeSeries(host: BatteryHost): void
 {
     const chargeIds    = host._energyDefaults.batteryStatEnergyTos;
@@ -327,10 +328,16 @@ function fetchBatteryChangeSeries(host: BatteryHost): void
     const today0 = new Date();
     today0.setHours(0, 0, 0, 0);
     const startMs = today0.getTime() - 2 * 24 * 3_600_000;
-    const endMs   = Date.now();
+    //End anchor rounded down to the refresh boundary. Folding it into the fetch key re-arms the
+    //gate once per CHANGE_REFRESH_MS, so the live-chip fallback and the past curve keep tracking
+    //newly committed recorder buckets (a startMs-only key froze the series at mount-time data
+    //until midnight: a battery idle at page load showed 0 W for the rest of the day). Rounding
+    //also lands every card on the same energy-stats cache key, so an N-card dashboard still hits
+    //the recorder once per interval.
+    const endMs   = changeRefreshAnchorMs();
     const sortedCharge    = [...chargeIds].sort();
     const sortedDischarge = [...dischargeIds].sort();
-    const key = `${sortedCharge.join(',')}|${sortedDischarge.join(',')}|${startMs}`;
+    const key = `${sortedCharge.join(',')}|${sortedDischarge.join(',')}|${startMs}|${endMs}`;
     if (key === host._batteryChangeFetchKey) { return; }
     host._batteryChangeFetchKey = key;
     host._batteryChangeFetching = true;

--- a/src/card/energy-prefs.ts
+++ b/src/card/energy-prefs.ts
@@ -38,10 +38,11 @@ export interface EnergyDefaults
     //per-source capacity.
     batteryStatSocs:        string[];
     //Entity ids whose raw value reads with the inverse sign convention from the rest of the card (the user wired the
-    //source through `power_config.stat_rate_inverted` instead of `stat_rate`, or through `stat_rate_from` for grid /
-    //`stat_rate_to` for battery, where the slot's directional meaning flips the sign vs the card's "positive = charging
-    /// positive = import" convention). Consumers (refreshBattery, refreshGrid) flip the sign at sample time so the
-    //downstream chips / leaders / scrub buffers see the canonical convention.
+    //source through `power_config.stat_rate_inverted` instead of `stat_rate`, or through a directional slot whose
+    //meaning opposes the card's canonical sign: `stat_rate_from` for battery (power FROM the battery = discharging,
+    //negative under "positive = charging") and `stat_rate_to` for grid (power TO the grid = exporting, negative under
+    //"positive = import"). Consumers (refreshBattery, refreshGrid) flip the sign at sample time so the downstream
+    //chips / leaders / scrub buffers see the canonical convention.
     invertedRateEntities:   string[];
 }
 
@@ -463,8 +464,7 @@ export function parseEnergyPrefs(prefs: {
             }
             else
             {
-                const slot = pickPowerConfigRate(src['power_config']);
-                if (slot)
+                for (const slot of collectPowerConfigRates(src['power_config'], 'grid'))
                 {
                     out.gridStatRates.push(slot.entity);
                     if (slot.inverted)
@@ -491,8 +491,11 @@ export function parseEnergyPrefs(prefs: {
             {
                 out.batteryStatSocs.push(soc);
             }
-            const slot = pickPowerConfigRate(src['power_config']);
-            if (slot)
+            //NOTE: a battery source can ALSO carry a top-level `stat_rate` (HA 2026 materialises a combined
+            //"net power" statistic for its power-flow view when both directional slots are wired). It is
+            //deliberately not read here: the directional pair below already nets to the same value, and
+            //summing both would double-count.
+            for (const slot of collectPowerConfigRates(src['power_config'], 'battery'))
             {
                 out.batteryStatRates.push(slot.entity);
                 if (slot.inverted)
@@ -506,37 +509,57 @@ export function parseEnergyPrefs(prefs: {
 }
 
 
-//Resolve a `power_config` slot. Returns `{ entity, inverted }` so the consumer can flip the sign at sample time when
-//the user wired the source through `stat_rate_inverted` (HA Energy's own UI toggle). Returns null when the block is
-//absent or none of the slots carry a usable entity id.
-function pickPowerConfigRate(raw: unknown): { entity: string; inverted: boolean } | null
+//Collect every live-power entity wired in a `power_config` block, each with the sign flip its slot needs to land on
+//the card's canonical convention (battery: positive = charging, grid: positive = import).
+//
+//The slot semantics mirror HA's energy-meter naming, "from the source" / "to the source":
+//  - `stat_rate` / `stat_rate_inverted`: ONE signed net sensor, already canonical (or wired flipped via HA Energy's
+//    own invert toggle).
+//  - `stat_rate_from`: unsigned power flowing FROM the source, i.e. battery discharge / grid import. Canonical sign:
+//    negative for battery (discharging), positive for grid (importing).
+//  - `stat_rate_to`: unsigned power flowing TO the source, i.e. battery charge / grid export. Canonical sign:
+//    positive for battery (charging), negative for grid (exporting).
+//
+//A source can carry BOTH directional slots at once (separate charge + discharge wattmeters, e.g. a Zendure exposes
+//import and export power as two entities). Reading only one of the pair, which is what this helper did before, shows
+//0 W whenever the other direction is active and the wrong sign the rest of the time, so every populated slot lands
+//in the list and the consumer sums them.
+function collectPowerConfigRates(raw: unknown, flavor: 'grid' | 'battery'): Array<{ entity: string; inverted: boolean }>
 {
     if (!raw || typeof raw !== 'object')
     {
-        return null;
+        return [];
     }
-    const pc = raw as Record<string, unknown>;
+    const pc  = raw as Record<string, unknown>;
+    const out: Array<{ entity: string; inverted: boolean }> = [];
+    //Net slots first, and EXCLUSIVE of the directional pair: a signed net sensor already carries
+    //both directions, so summing it together with from/to would double-count. Matches the strict
+    //priority the previous single-slot resolver had.
     const direct = pickFirstString(pc['stat_rate']);
     if (direct)
     {
-        return { entity: direct, inverted: false };
+        out.push({ entity: direct, inverted: false });
     }
-    const inverted = pickFirstString(pc['stat_rate_inverted']);
-    if (inverted)
+    const flipped = pickFirstString(pc['stat_rate_inverted']);
+    if (flipped)
     {
-        return { entity: inverted, inverted: true };
+        out.push({ entity: flipped, inverted: true });
+    }
+    if (out.length > 0)
+    {
+        return out;
     }
     const fromEntity = pickFirstString(pc['stat_rate_from']);
     if (fromEntity)
     {
-        return { entity: fromEntity, inverted: false };
+        out.push({ entity: fromEntity, inverted: flavor === 'battery' });
     }
     const toEntity = pickFirstString(pc['stat_rate_to']);
     if (toEntity)
     {
-        return { entity: toEntity, inverted: false };
+        out.push({ entity: toEntity, inverted: flavor === 'grid' });
     }
-    return null;
+    return out;
 }
 
 

--- a/src/card/energy-stats.ts
+++ b/src/card/energy-stats.ts
@@ -21,6 +21,23 @@
 const HOUR_MS = 3_600_000;
 
 
+//Re-fetch cadence for the change-series gates in pv.ts / grid.ts / battery.ts. The recorder
+//commits a new 5-minute statistics bucket every 5 minutes; re-arming the per-host fetch gate once
+//a minute keeps the cumulative-only live chips within ~1 min of the freshest committed bucket
+//without WS spam. Callers fold floor(now / CHANGE_REFRESH_MS) into their fetch key so the gate
+//re-arms on this boundary instead of only when the window origin shifts at midnight.
+export const CHANGE_REFRESH_MS = 60_000;
+
+//"Now" rounded down to the refresh boundary, the single anchor every change-series fetch gate
+//folds into its key (and battery / grid also pass as the fetch end). One helper instead of three
+//hand-rolled roundings so the call sites cannot drift apart, and so every card on a dashboard
+//computes the identical anchor and shares one cache entry per interval.
+export function changeRefreshAnchorMs(): number
+{
+    return Math.floor(Date.now() / CHANGE_REFRESH_MS) * CHANGE_REFRESH_MS;
+}
+
+
 //One recorder change bucket: the energy delta in kWh over [startMs, endMs). Already reset-
 //corrected and unit-normalised by the recorder.
 export interface ChangeBucket
@@ -39,17 +56,34 @@ export type StatPeriod = '5minute' | 'hour' | 'day';
 
 
 //Module-level cache shared across every Helios card on the page so an N-card dashboard hits the
-//recorder once per (window | period | statIds) tuple. TTL undershoots the card's 30 s tick so the
-//cached series survives the whole interval between refreshes; inflight requests dedup so concurrent
-//cards never race two parallel calls.
+//recorder once per (window | period | statIds) tuple. TTL undershoots CHANGE_REFRESH_MS by a few
+//seconds: within one re-arm interval every card lands on the same key and shares one recorder hit,
+//and the rounded end anchor in the callers' keys guarantees nobody is ever served data older than
+//one interval. Inflight requests dedup so concurrent cards never race two parallel calls.
 interface CacheEntry
 {
     ts:        number;
     result:    ChangeBucket[] | null;
     inflight?: Promise<ChangeBucket[] | null>;
 }
-const TTL_MS = 25_000;
+const TTL_MS = CHANGE_REFRESH_MS - 5_000;
 const _cache = new Map<string, CacheEntry>();
+
+//Drop every settled entry past its TTL. The re-arm scheme retires a (window | period | statIds)
+//key every CHANGE_REFRESH_MS, so without eviction the map gains an entry (with its full parsed
+//bucket array) per series per minute for the lifetime of the page: hundreds of MB per day on an
+//always-on wall-mounted dashboard. Called on every fetch; the map never holds more than a few
+//live entries so the sweep is O(handful).
+function pruneExpired(cache: Map<string, { ts: number; inflight?: unknown }>, nowMs: number): void
+{
+    for (const [key, e] of cache)
+    {
+        if (!e.inflight && nowMs - e.ts > TTL_MS)
+        {
+            cache.delete(key);
+        }
+    }
+}
 
 export function clearEnergyStatsCache(): void
 {
@@ -77,6 +111,7 @@ export async function fetchChangeSeries(
 
     const cacheKey = `${period}|${startMs}|${endMs}|${[...statisticIds].sort().join('|')}`;
     const nowMs    = Date.now();
+    pruneExpired(_cache, nowMs);
     const cached   = _cache.get(cacheKey);
     if (cached)
     {
@@ -177,6 +212,7 @@ export async function fetchMeanSeries(
 
     const cacheKey = `${period}|${startMs}|${endMs}|${[...statisticIds].sort().join('|')}`;
     const nowMs    = Date.now();
+    pruneExpired(_meanCache, nowMs);
     const cached   = _meanCache.get(cacheKey);
     if (cached)
     {

--- a/src/card/grid.ts
+++ b/src/card/grid.ts
@@ -20,7 +20,7 @@
 import { pvNormalizeToWatts } from './pv';
 import type { EnergyDefaults } from './energy-prefs';
 import { beginLoadingPhase, endLoadingPhase, type LoadingTrackerHost } from './loading-tracker';
-import { fetchChangeSeries, latestWattsFromChangeSeries, type ChangeBucket } from './energy-stats';
+import { fetchChangeSeries, latestWattsFromChangeSeries, changeRefreshAnchorMs, type ChangeBucket } from './energy-stats';
 
 
 export interface GridHost extends LoadingTrackerHost
@@ -85,9 +85,10 @@ export function refreshGrid(host: GridHost): void
 
 
 //Fetch the recorder `change` series for a direction's energy meters over the store's past window
-//(2 days back to now), gated on a per-host fetch key so it reissues only when the entity set or
-//window changes. The window matches the unified store's J-2 origin so the timeline + dashboard
-//graph have a real sample for every past bucket.
+//(2 days back to now), gated on a per-host fetch key that re-arms every CHANGE_REFRESH_MS (and on
+//entity-set / window changes) so the series keeps tracking newly committed recorder buckets. The
+//window matches the unified store's J-2 origin so the timeline + dashboard graph have a real
+//sample for every past bucket.
 function fetchGridChangeSeries(host: GridHost, slot: 'import' | 'export'): void
 {
     const ed = host._energyDefaults;
@@ -102,9 +103,12 @@ function fetchGridChangeSeries(host: GridHost, slot: 'import' | 'export'): void
     const today0 = new Date();
     today0.setHours(0, 0, 0, 0);
     const startMs = today0.getTime() - 2 * 24 * 3_600_000;
-    const endMs   = Date.now();
+    //Same re-arm scheme as fetchBatteryChangeSeries: the rounded end anchor in the key re-issues
+    //the fetch once per CHANGE_REFRESH_MS, so a cumulative-only grid wiring keeps a live chip and
+    //a fresh past curve instead of freezing at mount-time data until midnight.
+    const endMs   = changeRefreshAnchorMs();
     const sorted  = [...ids].sort();
-    const key     = `${sorted.join(',')}|${startMs}`;
+    const key     = `${sorted.join(',')}|${startMs}|${endMs}`;
 
     const prevKey = slot === 'import' ? host._gridImportChangeFetchKey : host._gridExportChangeFetchKey;
     if (key === prevKey) { return; }

--- a/src/card/overlays.ts
+++ b/src/card/overlays.ts
@@ -65,6 +65,7 @@ export interface LabelLayout
     batteryPowerLabel: { x: number; y: number };
     gridImportLabel:   { x: number; y: number };
     gridExportLabel:   { x: number; y: number };
+    homeUsageLabel:    { x: number; y: number };
     ringEdge:          { x: number; y: number };
     home:              { x: number; y: number };
     //Projected screen position of the home roof top (home lat/lon at
@@ -179,6 +180,7 @@ function labelLayoutEq(a: LabelLayout | null, b: LabelLayout | null): boolean
         && pointEq(a.batteryPowerLabel, b.batteryPowerLabel)
         && pointEq(a.gridImportLabel,   b.gridImportLabel)
         && pointEq(a.gridExportLabel,   b.gridExportLabel)
+        && pointEq(a.homeUsageLabel,    b.homeUsageLabel)
         && pointEq(a.ringEdge,          b.ringEdge)
         && pointEq(a.home,              b.home)
         //homeAnchorPoints is a long SVG points string; direct

--- a/src/card/pv.ts
+++ b/src/card/pv.ts
@@ -15,7 +15,7 @@ import { formatLocalisedNumber } from './format';
 import { resolveBatteryEntities } from './battery';
 import { callWSWithTimeout, WsTimeoutError } from './ws-timeout';
 import { beginLoadingPhase, endLoadingPhase, type LoadingTrackerHost } from './loading-tracker';
-import { fetchChangeSeries, latestWattsFromChangeSeries, wattsAtFromChangeSeries, type ChangeBucket } from './energy-stats';
+import { fetchChangeSeries, latestWattsFromChangeSeries, wattsAtFromChangeSeries, changeRefreshAnchorMs, type ChangeBucket } from './energy-stats';
 
 
 //Resolve the live PV entity from the HA Energy dashboard solar source. Prefers the optional `stat_rate` (signed W or kW)
@@ -401,7 +401,11 @@ export function refreshPv(host: PvHost): void
     {
         const seriesStart = new Date(today0.getTime() - 2 * 24 * HOUR_MS);
         const sortedChange = [...changeIds].sort();
-        const changeKey    = `${sortedChange.join(',')}|${seriesStart.getTime()}|${fetchEnd.getTime()}`;
+        //The refresh anchor re-arms the gate once per CHANGE_REFRESH_MS. fetchEnd alone (timeline
+        //range end) only moves when the engine shifts the time range (a weather refresh landing,
+        //the midnight rollover), far too coarse on its own: it froze the past curve and the
+        //cumulative-only live-chip fallback at mount-time data for hours.
+        const changeKey    = `${sortedChange.join(',')}|${seriesStart.getTime()}|${fetchEnd.getTime()}|${changeRefreshAnchorMs()}`;
         if (changeKey !== host._pvChangeSeriesFetchKey)
         {
             host._pvChangeSeriesFetchKey = changeKey;

--- a/src/css/helios-card-css.ts
+++ b/src/css/helios-card-css.ts
@@ -247,6 +247,7 @@ export const heliosCardStyles = css`
     .grid-leader-svg,
     .grid-import-label,
     .grid-export-label,
+    .home-usage-label,
     .home-pill
     {
         transition: opacity 0.35s ease;
@@ -270,6 +271,7 @@ export const heliosCardStyles = css`
     ha-card.overlay-masked .grid-leader-svg,
     ha-card.overlay-masked .grid-import-label,
     ha-card.overlay-masked .grid-export-label,
+    ha-card.overlay-masked .home-usage-label,
     ha-card.overlay-masked .home-pill
     {
         will-change: opacity;
@@ -296,7 +298,8 @@ export const heliosCardStyles = css`
     ha-card.overlay-masked .battery-pct-label,
     ha-card.overlay-masked .grid-leader-svg,
     ha-card.overlay-masked .grid-import-label,
-    ha-card.overlay-masked .grid-export-label
+    ha-card.overlay-masked .grid-export-label,
+    ha-card.overlay-masked .home-usage-label
     {
         opacity: 0;
         pointer-events: none;
@@ -2988,7 +2991,8 @@ export const heliosCardStyles = css`
         consumption blue for import, return purple for export. Both
         chips live in the LEFT column of the home cluster. */
     .grid-import-label,
-    .grid-export-label
+    .grid-export-label,
+    .home-usage-label
     {
         position: absolute;
         transform: translate(-50%, -50%);
@@ -3021,8 +3025,19 @@ export const heliosCardStyles = css`
     {
         border: 2px solid var(--energy-grid-return-color, #8353d1);
     }
+    /*  Home consumption chip carries the home cluster's family signature (HA primary colour, same
+        as the home pill + drop leader) so it reads as the home node's own readout, not as a fifth
+        energy source. Left-edge anchored (translate Y only): the layout x is the chip's LEFT edge
+        docked against the home pill's right side, so growing value text expands AWAY from the
+        pill instead of pushing into it. */
+    .home-usage-label
+    {
+        border: 2px solid var(--primary-color, #03a9f4);
+        transform: translate(0, -50%);
+    }
     .grid-import-label ha-icon,
-    .grid-export-label ha-icon
+    .grid-export-label ha-icon,
+    .home-usage-label ha-icon
     {
         --mdc-icon-size: 16px;
         color: inherit;
@@ -3515,6 +3530,7 @@ export const heliosCardStyles = css`
         .battery-pct-label,
         .grid-import-label,
         .grid-export-label,
+        .home-usage-label,
         .solar-pct-label
         {
             font-size: var(--ha-font-size-m, 14px);
@@ -3524,6 +3540,7 @@ export const heliosCardStyles = css`
         .battery-pct-label ha-icon,
         .grid-import-label ha-icon,
         .grid-export-label ha-icon,
+        .home-usage-label ha-icon,
         .solar-pct-label ha-icon
         {
             --mdc-icon-size: 18px;

--- a/src/helios-card.ts
+++ b/src/helios-card.ts
@@ -1674,6 +1674,33 @@ export class HeliosCard extends LitElement
             ? formatBatteryPower(this.hass, activeBatteryPower!, activeBatteryUnit)
             : '';
 
+        //Home consumption chip. Same client-side derivation as the official "Now" view's Power
+        //usage header (`hui-power-sankey-card._computePowerData`):
+        //  used_total = from_grid + solar + from_battery - to_grid - to_battery
+        //expressed here over the card's already scrub-aware per-family values, so the chip shows
+        //the same number HA shows live AND follows the timeline scrub like every other chip.
+        //Families contribute only when they have a reading; with nothing wired the chip hides.
+        //Clamped at zero: a small negative is meter skew, not physical negative consumption.
+        const usagePvW = (!pvScrubFuture && pvActiveRate !== null)
+            ? pvNormalizeToWatts(pvActiveRate.value, pvActiveRate.unit)
+            : null;
+        const usageGridW = (gridImportDisplayWatts !== null || gridExportDisplayWatts !== null)
+            ? (gridImportDisplayWatts ?? 0) - (gridExportDisplayWatts ?? 0)
+            : null;
+        //activeBatteryPower is charge-positive, so it SUBTRACTS: charging is consumption that
+        //never reaches the home, discharging (negative) adds supply.
+        const usageBatteryW = showPowerChip ? activeBatteryPower! : null;
+        const homeUsageWatts = (usagePvW === null && usageGridW === null && usageBatteryW === null)
+            ? null
+            : Math.max(0, (usagePvW ?? 0) + (usageGridW ?? 0) - (usageBatteryW ?? 0));
+        const showHomeUsageChip = hasHomeCoords
+            && layout !== null
+            && !batteryScrubFuture
+            && homeUsageWatts !== null;
+        const homeUsageText = showHomeUsageChip
+            ? formatGridValue(homeUsageWatts, 'W')
+            : '';
+
         //Charging / discharging direction drives the SVG arrow path direction on the PV↔Power
         //leader, off the PHYSICAL sign (positive = charging). Charging: arrow flows PV → Power
         //(energy moving INTO the battery), dashes at a speed proportional to |P| saturating at the
@@ -2757,6 +2784,21 @@ export class HeliosCard extends LitElement
                         style="left:${layout!.home.x}px; top:${layout!.home.y}px"
                     >
                         <ha-icon icon="mdi:home"></ha-icon>
+                    </div>
+                ` : nothing}
+
+                <!--  Home consumption chip, docked to the right of
+                      the home pill. Value mirrors the official
+                      Energy "Now" header (Power usage), same
+                      client-side formula over the same HA Energy
+                      sources, so the two surfaces always agree.     -->
+                ${showHomeUsageChip && !this._detailMode ? html`
+                    <div
+                        class="home-usage-label"
+                        style="left:${layout!.homeUsageLabel.x}px; top:${layout!.homeUsageLabel.y}px"
+                    >
+                        <ha-icon icon="mdi:home-lightning-bolt"></ha-icon>
+                        <span>${homeUsageText}</span>
                     </div>
                 ` : nothing}
 

--- a/src/helios-card.ts
+++ b/src/helios-card.ts
@@ -1664,12 +1664,14 @@ export class HeliosCard extends LitElement
         const batterySocText = showSocChip
             ? `${Math.round(activeBatterySoc!)} %`
             : '';
-        //Chip value uses HA's Energy Sources sign convention: discharge positive (the battery
-        //supplies power), charge negative (it consumes / stores). `activeBatteryPower` is the
-        //physical charge-positive net, so negate it for the displayed sign. The colour + leader flow
-        //below stay on the physical value so charging still reads pink + flows INTO the battery.
+        //Chip value uses the battery-centric physical sign: charge positive (+ = energy flowing
+        //INTO the battery), discharge negative. This is the same convention as every other battery
+        //surface in the card (unified store, scrub buffers, leader direction) but the OPPOSITE of
+        //HA's "Power sources" graph, which draws the battery source-centric (positive when it
+        //supplies the home). On a standalone chip the physical read is the intuitive one: testers
+        //consistently parsed "−" while charging as a wiring bug.
         const batteryPowerText = showPowerChip
-            ? formatBatteryPower(this.hass, -activeBatteryPower!, activeBatteryUnit)
+            ? formatBatteryPower(this.hass, activeBatteryPower!, activeBatteryUnit)
             : '';
 
         //Charging / discharging direction drives the SVG arrow path direction on the PV↔Power

--- a/src/helios-engine.ts
+++ b/src/helios-engine.ts
@@ -4471,6 +4471,7 @@ export class HeliosEngine
         batteryPowerLabel: { x: number; y: number };
         gridImportLabel:   { x: number; y: number };
         gridExportLabel:   { x: number; y: number };
+        homeUsageLabel:    { x: number; y: number };
         ringEdge:          { x: number; y: number };
         home:              { x: number; y: number };
         //Projected screen position of the home building's roof top
@@ -4675,6 +4676,7 @@ export class HeliosEngine
             batteryPowerLabel: { x: batteryXRight,  y: batteryPowerY},
             gridImportLabel:   { x: gridXLeft,      y: gridImportY  },
             gridExportLabel:   { x: gridXLeft,      y: gridExportY  },
+            homeUsageLabel:    { x: home.x + 22,    y: clusterY     },
             ringEdge:          { x: ringEdgeX,      y: ringEdgeY    },
             home:              { x: home.x,         y: clusterY     },
             homeRoof:          { x: home.x,         y: roofY        },


### PR DESCRIPTION
**Fix 1: `power_config` directional pair misread.** A battery or grid source wired with separate directional power sensors (`stat_rate_from` + `stat_rate_to`, e.g. a Zendure's charge and discharge wattmeters) only had its first slot read, interpreted as a signed net sensor: the battery chip pinned at 0 W while charging, and discharge was shown with the wrong sign. All populated slots are now collected with HA's documented direction semantics (`stat_rate_from` = battery discharge / grid consumption, `stat_rate_to` = battery charge / grid return) and summed; net slots stay exclusive of the directional pair to prevent double-counting. The single-sensor battery modes had a related sign bug: per HA's dialog copy, a battery "Standard" sensor is discharge-positive and "Inverted" is charge-positive, but both were read as charge-positive, so Standard-mode batteries showed discharge as charging. The battery flavor now flips `stat_rate` and leaves `stat_rate_inverted` unflipped; grid conventions were already correct.

**Fix 2: change-series fetch gates froze at mount.** The recorder `change`-series fetch keys in `battery.ts` / `grid.ts` / `pv.ts` only rolled at midnight, freezing cumulative-only live chips, timeline curves, scrub tooltips, and radial daily totals at page-load state. Gates now re-arm every 60 s via a shared anchor (`changeRefreshAnchorMs`); the stats cache TTL derives from the same cadence so an N-card dashboard shares one recorder hit per interval, and expired cache entries are evicted (previously unbounded growth on always-on wall dashboards).

**Behavior change: battery chip sign is now battery-centric** (+ charging / − discharging). Testers consistently read the old source-centric "−" during charging as a wiring bug; the chip now matches the physical charge-positive convention used by every other battery surface in the card. Happy to gate this behind an option if you prefer the old default.

**Feature: home consumption chip** docked beside the home pill, computed with the official Energy "Now" header's exact formula (`used_total = from_grid + solar + from_battery − to_grid − to_battery`) over the card's scrub-aware per-family values, so it matches HA live and follows the timeline scrub. Hidden when no family has a reading; clamps small negative meter skew to zero.
