### PR TITLE
Feat: opt-in per-bank battery SoC on the live chip (battery-soc-per-bank)

### DIFF
--- a/README.md
+++ b/README.md
@@ -189,6 +189,7 @@ The visual editor exposes every option below. Direct YAML editing also works.
 | `power-unit` | `W` \| `kW` | `kW` | Unit for every power readout (chips, tooltips, dial). Energy follows it, so `kW` pairs with `kWh` and `W` with `Wh`. |
 | `irradiance-unit` | `W/m²` \| `kW/m²` | `W/m²` | Unit for the solar-constant (irradiance) readout above the sun. |
 | `battery-sign` | `default` \| `inverted` \| `hidden` | `default` | Sign shown on the battery chip: `default` (minus charging, plus discharging), `inverted`, or `hidden` (magnitude only). Display-only; flows and history are unchanged. |
+| `battery-soc-per-bank` | boolean | `false` | With several battery sources wired, the live SoC chip lists every bank ("100 · 82 %", Energy-dashboard source order) instead of the mean. Scrubbing keeps the mean (SoC history is stored aggregated). |
 
 The rolling window itself is chosen live from the timeline's period selector (**Standard**, **Today**, **Week**, **Month**, **Year**) and remembered per card; it needs no YAML key.
 

--- a/src/core/config/helios-config.ts
+++ b/src/core/config/helios-config.ts
@@ -92,6 +92,10 @@ export interface HeliosConfig
     //Battery chip sign convention: 'default' (- charging, + discharging), 'inverted' (+ charging,
     //- discharging), or 'hidden' (magnitude only). Display-only; flow direction and history are unchanged.
     'battery-sign'?:           unknown;
+    //Battery SoC chip layout for multi-bank installs: when true and several battery sources are wired,
+    //the live chip lists every bank ("100 · 82 %", Energy-dashboard source order) instead of the mean.
+    //Scrub keeps the mean (SoC history is stored aggregated). Default false.
+    'battery-soc-per-bank'?:   unknown;
     //"No UI" mode: when true, the timeline and the on-card controls fade away after a short idle and reappear on
     //any input (kiosk/immersive display). Default false. See UI_AUTOHIDE_MS.
     'auto-hide-ui'?:           unknown;
@@ -203,6 +207,13 @@ export function batterySign(config: HeliosConfig | undefined): 'default' | 'inve
 {
     const raw = config?.['battery-sign'];
     return raw === 'inverted' || raw === 'hidden' ? raw : 'default';
+}
+
+
+//Resolved per-bank battery SoC chip flag. Default false, so existing cards keep the aggregated mean.
+export function batterySocPerBank(config: HeliosConfig | undefined): boolean
+{
+    return config?.['battery-soc-per-bank'] === true;
 }
 
 

--- a/src/core/i18n/index.ts
+++ b/src/core/i18n/index.ts
@@ -133,6 +133,8 @@ export interface Translations
         batterySignDefault?:          string;
         batterySignInverted?:         string;
         batterySignHidden?:           string;
+        batterySocPerBank?:           string;
+        batterySocPerBankHint?:       string;
         //"No UI" mode toggle (auto-hide the timeline + controls). Optional; fall back to English.
         noUiMode?:                    string;
         noUiModeHint?:                string;

--- a/src/core/i18n/locales/en-GB.ts
+++ b/src/core/i18n/locales/en-GB.ts
@@ -52,6 +52,8 @@ export const enGB: Translations = {
         batterySignDefault:           'Default',
         batterySignInverted:          'Inverted',
         batterySignHidden:            'Hidden',
+        batterySocPerBank:            'Battery SoC per bank',
+        batterySocPerBankHint:        'With several battery sources wired, the live SoC chip lists every bank ("100 · 82 %", Energy dashboard order) instead of the average. Scrubbing keeps the average.',
         noUiMode:                     'No UI mode',
         noUiModeHint:                 'Fade the timeline and the on-card controls after a few seconds of inactivity. Any tap or move brings them back. Great for a wall display.',
         installationSection: 'PV installation',

--- a/src/core/i18n/locales/en.ts
+++ b/src/core/i18n/locales/en.ts
@@ -61,6 +61,8 @@ export const en: Translations = {
         batterySignDefault:           'Default',
         batterySignInverted:          'Inverted',
         batterySignHidden:            'Hidden',
+        batterySocPerBank:            'Battery SoC per bank',
+        batterySocPerBankHint:        'With several battery sources wired, the live SoC chip lists every bank ("100 · 82 %", Energy dashboard order) instead of the average. Scrubbing keeps the average.',
         noUiMode:                     'No UI mode',
         noUiModeHint:                 'Fade the timeline and the on-card controls after a few seconds of inactivity. Any tap or move brings them back. Great for a wall display.',
         installationSection: 'PV installation',

--- a/src/editor/editor.ts
+++ b/src/editor/editor.ts
@@ -688,6 +688,7 @@ export class HeliosCardEditor extends LitElement
                     ` : nothing}
                 </div>
                 <div class="field-help">${t.editor.batterySignHelp ?? 'Sign shown on the battery chip: default (minus while charging), inverted (plus while charging), or hidden.'}</div>
+                ${this._renderToggle('battery-soc-per-bank', t.editor.batterySocPerBank ?? 'Battery SoC per bank', t.editor.batterySocPerBankHint ?? 'With several battery sources wired, the live SoC chip lists every bank ("100 · 82 %", Energy dashboard order) instead of the average. Scrubbing keeps the average.')}
                 <div class="hint">${t.editor.customEntityIntro ?? 'Custom entity: displayed only when BOTH sensors below are set. The power sensor feeds the live chip and the curve, the energy sensor feeds the energy views. Nothing is estimated.'}</div>
                 ${this._customLegacyPending() ? html`
                     <div class="hint reset-warning">${t.editor.customLegacyHint ?? 'Your previous custom entity was moved to its matching field below. Add the missing sensor to show the chip again.'}</div>

--- a/src/hud/scene-hud-controller.ts
+++ b/src/hud/scene-hud-controller.ts
@@ -1,9 +1,9 @@
 import type { TemplateResult } from 'lit';
 import { html, svg, nothing } from 'lit';
 import type { HeliosCard } from '../helios-card';
-import { valueDecimals, powerUnit, irradianceUnit, batterySign, customEntityId, customEntityColor } from '../core/config/helios-config';
+import { valueDecimals, powerUnit, irradianceUnit, batterySign, batterySocPerBank, customEntityId, customEntityColor } from '../core/config/helios-config';
 import { resolveCustomEntityLive, resolveCustomEntityIcon, customChipWatts } from '../data/sources/custom-entity';
-import { darkenHex, ENERGY_COLOR, cloudCoverIcon, formatHaTime, formatIrradiance, resolveUiColor } from '../core/format/format';
+import { darkenHex, ENERGY_COLOR, cloudCoverIcon, formatHaTime, formatIrradiance, resolveUiColor, parseNumericState } from '../core/format/format';
 import { currentPvRate, pvRateAtTime, pvNormalizeToWatts, formatPvValue, resolvePvLiveEntity } from '../data/sources/pv';
 import { batterySampleAtTime, formatBatteryPower, resolveBatteryEntities } from '../data/sources/battery';
 import { buildArcSegments, flowDuration, type LabelLayout } from './hud';
@@ -280,9 +280,34 @@ export class SceneHudController
             && hasAnyBankPower
             && activeBatteryPower !== null;
 
-        const batterySocText = showSocChip
-            ? `${Math.round(activeBatterySoc!)} %`
-            : '';
+        //Battery SoC chip text: the aggregated mean by default. With `battery-soc-per-bank` and several
+        //wired banks, the live chip lists every bank instead ("100 · 82 %", Energy-dashboard source order)
+        //so a multi-bank install reads per-bank at a glance. Scrub keeps the mean (SoC history is stored
+        //aggregated), and any unreadable bank falls back to the mean (a partial list would misassign banks).
+        let batterySocText = '';
+        if (showSocChip)
+        {
+            batterySocText = `${Math.round(activeBatterySoc!)} %`;
+            const perBankIds = this.host._energyDefaults.batteryStatSocs;
+            if (batterySocPerBank(this.host.config) && !batteryScrubbing && perBankIds.length > 1)
+            {
+                const perBank: string[] = [];
+                for (const id of perBankIds)
+                {
+                    const so = this.host.hass.states?.[id];
+                    const v  = so ? parseNumericState(so.state) : null;
+                    if (v === null)
+                    {
+                        break;
+                    }
+                    perBank.push(`${Math.round(Math.max(0, Math.min(100, v)))}`);
+                }
+                if (perBank.length === perBankIds.length)
+                {
+                    batterySocText = `${perBank.join(' · ')} %`;
+                }
+            }
+        }
         //Chip uses the HA energy dashboard sign convention (discharge positive, charge negative).
         //activeBatteryPower is the physical charge-positive net, so it's negated for display to stay
         //coherent with the dashboard. Colour + leader direction below keep the physical sign.


### PR DESCRIPTION
## What

A new display option, `battery-soc-per-bank` (boolean, default `false`). With several battery sources wired on the Energy dashboard, the live SoC chip lists every bank — `100 · 82 %`, in Energy-dashboard source order — instead of the arithmetic mean.

## Why

On a multi-bank install the mean hides exactly what you watch the chip for: a healthy bank masks a sagging one. Mine is a two-bank off-grid setup (a 400 W camera array and a 200 W gate array, one LiFePO4 bank each). "91 %" reads fine while the gate bank sits at 82 and dropping; `100 · 82 %` tells the truth at a glance.

## Behaviour

- Default `false` — nothing changes for existing cards.
- Live mode only. Scrubbing keeps the mean: SoC history is stored aggregated and this PR doesn't touch that pipeline.
- If any wired bank is unreadable, the chip falls back to the mean rather than showing a partial list that would misassign banks.
- Values clamped to 0–100, same as the aggregated path.
- Chip text only: leaders, beads, history and the home balance keep the aggregate pipeline.

## Scope

Config declaration + resolver, chip text in `SceneHudController`, an editor toggle next to the battery-sign field, a README row, and i18n keys with English strings (`en`, `en-GB`). The other locales are left to your translation pipeline — happy to fill them here instead if you prefer. Source-only; no `dist` committed since release.yml builds it.

## Testing

`npm run typecheck` and `npm run build` are clean on this branch. The same chip logic (unconditional, backported onto 2026.7.4) has been running in production on my two-bank system since 2026-07-06, on a Raspberry Pi kiosk running Chromium 101 — the chip reads `100 · 99 %` live.

Thanks for Helios — and for `power-unit: W` in 2026.7.2, which made the card genuinely usable at watt scale for small off-grid systems like mine.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0169KRbqdRLPtJVz3ZXmF4Rb
