### PR TITLE
feat(sandbox): add standalone interactive test sandbox with prototype overrides

### DIFF
--- a/sandbox/git-changes.patch
+++ b/sandbox/git-changes.patch
@@ -1,0 +1,515 @@
+diff --git a/src/card/init.ts b/src/card/init.ts
+index 8b402fb..5c3ec90 100644
+--- a/src/card/init.ts
++++ b/src/card/init.ts
+@@ -45,11 +45,17 @@ const STATIC_VISUAL_CONFIG_KEYS = [
+     'display-radius',
+     //Scene zoom: updateConfig rescales the renderer's camera and drops the arc caches (helios-engine).
+     'scene-zoom',
++    //Arc zoom: scales the sun and moon arc radius up or down.
++    'arc-zoom',
++    //Battery z-index elevation above the solar arc.
++    'battery-above-arc',
+     'building-cluster-radius',
+     'building-count',
+     'building-real-size',
+     'building-height',
+     'building-opacity',
++    'shadows-enabled',
++    'shadow-opacity',
+     'auto-rotate-enabled',
+     //Lock toggle: a change triggers updateConfig, which freezes/frees the camera at its current (drag-set) pose and
+     //resyncs the stored pose. The buildings re-interpret that updateConfig also triggers is cheap (cached footprints, no refetch).
+diff --git a/src/core/config/constants.ts b/src/core/config/constants.ts
+index 285daad..dbfda17 100644
+--- a/src/core/config/constants.ts
++++ b/src/core/config/constants.ts
+@@ -23,6 +23,12 @@ export const MAX_DISPLAY_RADIUS_M     = 250;
+ //and the shadows grow around the home while the HUD (arc, discs, chips) keeps its card-fitted size. 1 = as-is.
+ export const SCENE_ZOOM_LEVELS = [1, 1.5, 2] as const;
+ export const DEFAULT_SCENE_ZOOM = 1;
++export const MIN_SCENE_ZOOM     = 0.25;
++export const MAX_SCENE_ZOOM     = 2;
++//Sun/moon arc magnification (`arc-zoom`): multiplier on the target on-screen radius of the sun/moon arc. 1 = as-is.
++export const DEFAULT_ARC_ZOOM   = 1;
++export const MIN_ARC_ZOOM       = 0.25;
++export const MAX_ARC_ZOOM       = 2;
+ export const DEFAULT_BUILDING_OPACITY          = 0.5;   //ghost surround; home stays 1.0
+ export const DEFAULT_BUILDING_CLUSTER_RADIUS_M = 0;     //0 = single-polygon home detection
+ 
+diff --git a/src/core/config/helios-config.ts b/src/core/config/helios-config.ts
+index 2795fe2..6b8f08c 100644
+--- a/src/core/config/helios-config.ts
++++ b/src/core/config/helios-config.ts
+@@ -10,14 +10,16 @@ import {
+     DEFAULT_BUILDING_COUNT, MIN_BUILDING_COUNT, MAX_BUILDING_COUNT,
+     FIXED_BUILDING_HEIGHT_M, MIN_BUILDING_HEIGHT_M, MAX_BUILDING_HEIGHT_M,
+     DEFAULT_NO_UI_DELAY_S, MIN_NO_UI_DELAY_S, MAX_NO_UI_DELAY_S,
+-    SCENE_ZOOM_LEVELS, DEFAULT_SCENE_ZOOM,
++    SCENE_ZOOM_LEVELS, DEFAULT_SCENE_ZOOM, MIN_SCENE_ZOOM, MAX_SCENE_ZOOM,
++    DEFAULT_ARC_ZOOM, MIN_ARC_ZOOM, MAX_ARC_ZOOM,
+ } from './constants';
+ import { clamp } from '../render-kit/math';
+ 
+ export {
+     DEFAULT_BUILDING_OPACITY,
+     DEFAULT_BUILDING_CLUSTER_RADIUS_M, DEFAULT_DISPLAY_RADIUS_M, MIN_DISPLAY_RADIUS_M,
+-    SCENE_ZOOM_LEVELS, DEFAULT_SCENE_ZOOM,
++    SCENE_ZOOM_LEVELS, DEFAULT_SCENE_ZOOM, MIN_SCENE_ZOOM, MAX_SCENE_ZOOM,
++    DEFAULT_ARC_ZOOM, MIN_ARC_ZOOM, MAX_ARC_ZOOM,
+     MAX_DISPLAY_RADIUS_M, DEFAULT_DISPLAY_UPDATE_FREQUENCY_PER_HOUR,
+     MIN_DISPLAY_UPDATE_FREQUENCY_PER_HOUR, MAX_DISPLAY_UPDATE_FREQUENCY_PER_HOUR, DEFAULT_VALUE_DECIMALS,
+     MIN_VALUE_DECIMALS, MAX_VALUE_DECIMALS,
+@@ -127,6 +129,10 @@ export interface HeliosConfig
+     'moon-display'?:            unknown;
+     //Scene magnification, one of SCENE_ZOOM_LEVELS (1 = as-is). See sceneZoom().
+     'scene-zoom'?:              unknown;
++    //Sun/moon arc magnification (0.25 to 2, default 1). See arcZoom().
++    'arc-zoom'?:                unknown;
++    //When true, elevates the battery chip and its leader above the solar arc and sun disc. Default false.
++    'battery-above-arc'?:       unknown;
+     'sun-chip-mode'?:           unknown;
+     'battery-chip-mode'?:       unknown;
+     //Per-card cache id. When set, the saved view (mode, filters, camera pose, lock) keys on it instead of the
+@@ -329,16 +335,31 @@ export function moonDisplay(config: HeliosConfig | undefined): MoonDisplay
+     const v = config?.['moon-display'];
+     return v === 'always' || v === 'hidden' ? v : 'night';
+ }
+-//Scene magnification: 1 (the default, no magnification), 1.5 or 2. Multiplies the camera's px-per-metre, so the
++//Scene magnification: default 1. Multiplies the camera's px-per-metre, so the
+ //basemap, buildings and shadows grow around the home; the sun/moon arcs, discs and chips stay card-sized (the arc
+-//scale probe measures projected px per metre and compensates). Accepts a number or a numeric string (the editor's
+-//select emits strings); anything else falls back to 1.
+-export type SceneZoom = (typeof SCENE_ZOOM_LEVELS)[number];
+-export function sceneZoom(config: HeliosConfig | undefined): SceneZoom
++//scale probe measures projected px per metre and compensates). Accepts a number or a numeric string (between 0.25 and 2);
++//anything else falls back to 1.
++export type SceneZoom = number;
++export function sceneZoom(config: HeliosConfig | undefined): number
+ {
+     const raw = config?.['scene-zoom'];
+     const n = typeof raw === 'number' ? raw : typeof raw === 'string' ? Number(raw) : NaN;
+-    return (SCENE_ZOOM_LEVELS as readonly number[]).includes(n) ? (n as SceneZoom) : DEFAULT_SCENE_ZOOM;
++    return Number.isFinite(n) && n >= MIN_SCENE_ZOOM && n <= MAX_SCENE_ZOOM ? n : DEFAULT_SCENE_ZOOM;
++}
++
++//Sun/moon arc magnification: default 1. Scales the arc radius and related celestial elements.
++//Accepts a number or a numeric string (between 0.25 and 2); anything else falls back to 1.
++export function arcZoom(config: HeliosConfig | undefined): number
++{
++    const raw = config?.['arc-zoom'];
++    const n = typeof raw === 'number' ? raw : typeof raw === 'string' ? Number(raw) : NaN;
++    return Number.isFinite(n) && n >= MIN_ARC_ZOOM && n <= MAX_ARC_ZOOM ? n : DEFAULT_ARC_ZOOM;
++}
++
++//Whether the battery chip (and its leader) should be elevated in z-index over the solar arc and sun disc.
++export function batteryAboveArc(config: HeliosConfig | undefined): boolean
++{
++    return config?.['battery-above-arc'] === true;
+ }
+ 
+ //Configured colour for the horizon ridge line, as a ui_color token or hex. Undefined falls back to the card CSS.
+diff --git a/src/css/helios-card-scene-css.ts b/src/css/helios-card-scene-css.ts
+index cd82504..da6a16c 100644
+--- a/src/css/helios-card-scene-css.ts
++++ b/src/css/helios-card-scene-css.ts
+@@ -198,6 +198,29 @@ export const heliosCardStyles = css`
+         color: var(--primary-text-color, #212121);
+     }
+ 
++    /*  When battery-above-arc is enabled on ha-card, elevate all energy chips/pills (PV, battery, grid, home, groups, corner chips)
++        and their connection leaders above the solar arc (z 11) and sun disc (z 12). */
++    ha-card.battery-above-arc .pv-pct-label,
++    ha-card.battery-above-arc .battery-pct-label,
++    ha-card.battery-above-arc .grid-label,
++    ha-card.battery-above-arc .group-label,
++    ha-card.battery-above-arc .home-pill,
++    ha-card.battery-above-arc .home-ring
++    {
++        z-index: 13;
++    }
++    ha-card.battery-above-arc .helios-corner-chips
++    {
++        z-index: 13;
++    }
++    ha-card.battery-above-arc .pv-home-leader-svg,
++    ha-card.battery-above-arc .battery-leader-svg,
++    ha-card.battery-above-arc .grid-leader-svg,
++    ha-card.battery-above-arc .group-leader-svg
++    {
++        z-index: 12;
++    }
++
+     /*  PV production chip: pill tinted in the production colour (--pv-leader-color, set inline). Shares the
+         fixed width so the leader gap stays identical however wide the value reads. */
+     .pv-pct-label
+diff --git a/src/data/sources/weather-override.ts b/src/data/sources/weather-override.ts
+index 3378c6c..9021ee7 100644
+--- a/src/data/sources/weather-override.ts
++++ b/src/data/sources/weather-override.ts
+@@ -35,8 +35,8 @@ const OVERRIDES: readonly OverrideDef[] = [
+ ];
+ 
+ //The config keys above, for callers that need to know which entities feed this subsystem without depending on
+-//OverrideDef itself (e.g. the card's hass-churn reactivity gate).
+-export const WEATHER_OVERRIDE_CONFIG_KEYS: readonly string[] = OVERRIDES.map((o) => o.configKey);
++//OverrideDef itself (e.g. the card's hass-churn reactivity gate). Includes 'weather-entity' for the WMO code override.
++export const WEATHER_OVERRIDE_CONFIG_KEYS: readonly string[] = [...OVERRIDES.map((o) => o.configKey), 'weather-entity'];
+ 
+ //HA `weather` entity condition -> WMO weather code, so a weather entity can drive the condition (rain / snow /
+ //thunderstorm) the same way Open-Meteo's weather_code does. Unlisted conditions push no sample (model kept).
+diff --git a/src/helios-card.ts b/src/helios-card.ts
+index 3518db7..4395395 100644
+--- a/src/helios-card.ts
++++ b/src/helios-card.ts
+@@ -18,6 +18,7 @@ import
+     showCost,
+     showHorizonLine,
+     horizonLineColor,
++    batteryAboveArc,
+ } from './core/config/helios-config';
+ import { chipSlotColor, chipSlotIcon } from './core/config/chip-appearance';
+ import { buildDayProfile, daySlots, type ProfileStrand } from './data/period-totals/day-profile';
+@@ -1662,8 +1663,9 @@ export class HeliosCard extends LitElement
+         const activeChipColor = this._activeChipColor();
+         const cardClasses = [
+             cardThemeClass,
+-            cameraLocked      ? 'camera-locked'  : '',
+-            this.preview      ? 'helios-edit'    : '',
++            cameraLocked                 ? 'camera-locked'     : '',
++            this.preview                 ? 'helios-edit'       : '',
++            batteryAboveArc(this.config) ? 'battery-above-arc' : '',
+         ].filter(Boolean).join(' ');
+         //Selected-chip accent for the timeline + period-selector top borders (always), plus the detail-panel
+         //accent (same colour) only when the panel is open.
+diff --git a/src/scene/helios-engine.ts b/src/scene/helios-engine.ts
+index 41452a6..eb55d01 100644
+--- a/src/scene/helios-engine.ts
++++ b/src/scene/helios-engine.ts
+@@ -27,6 +27,7 @@ import
+     type HeliosConfig,
+     displayRadiusM,
+     sceneZoom,
++    arcZoom,
+     DEFAULT_BUILDING_OPACITY,
+     DEFAULT_BUILDING_CLUSTER_RADIUS_M,
+     DEFAULT_SHADOW_OPACITY,
+@@ -98,6 +99,106 @@ export type IrradianceSource = 'haurwitz' | 'shortwave' | 'sensor';
+ //sensor has no future data (the nearest-neighbour window below returns null past its reach).
+ export type WeatherOverrideVar = 'cloudCover' | 'precip' | 'snowfall' | 'temperature' | 'humidity' | 'code';
+ 
++//When the HA weather entity overrides the WMO code but no dedicated sensor overrides precip, snowfall or cloud
++//cover, the visual layers (rain/snow particles, cloud veil, grey filter) would still read the Open-Meteo model's
++//values — which may be zero (sunny day in the forecast). This helper fills in reasonable implied values from the
++//code so the layers match the declared condition. Each variable is only touched when it has no sensor override
++//(cloudOverride / precipOverride / snowOverride are null if no sensor override was resolved for that time).
++export function applyCodeImpliedWeather(
++    w:              { cloudCover: number; precip: number; snowfall: number },
++    code:           number,
++    cloudOverride:  number | null,
++    precipOverride: number | null,
++    snowOverride:   number | null,
++): void
++{
++    //WMO code → implied cloud cover (%), precipitation (mm/h) and snowfall (cm/h).
++    //Values are "representative moderate" so the condition reads visually without being over-the-top.
++    //Groups follow https://open-meteo.com/en/docs; codes not explicitly listed keep the model value.
++    let impliedCloud:    number | undefined;
++    let impliedPrecip:   number | undefined;
++    let impliedSnowfall: number | undefined;
++
++    if (code === 0)                                        //Clear sky
++    {
++        impliedCloud = 5;   impliedPrecip = 0;  impliedSnowfall = 0;
++    }
++    else if (code === 1)                                   //Mainly clear
++    {
++        impliedCloud = 20;  impliedPrecip = 0;  impliedSnowfall = 0;
++    }
++    else if (code === 2)                                   //Partly cloudy
++    {
++        impliedCloud = 50;  impliedPrecip = 0;  impliedSnowfall = 0;
++    }
++    else if (code === 3)                                   //Overcast
++    {
++        impliedCloud = 90;  impliedPrecip = 0;  impliedSnowfall = 0;
++    }
++    else if (code >= 45 && code <= 48)                     //Fog / depositing rime fog
++    {
++        impliedCloud = 95;  impliedPrecip = 0;  impliedSnowfall = 0;
++    }
++    else if (code >= 51 && code <= 55)                     //Drizzle (light → dense)
++    {
++        impliedCloud = 85;  impliedPrecip = 0.3 + (code - 51) * 0.2;  impliedSnowfall = 0;
++    }
++    else if (code >= 56 && code <= 57)                     //Freezing drizzle
++    {
++        impliedCloud = 90;  impliedPrecip = 0.4;  impliedSnowfall = 0;
++    }
++    else if (code >= 61 && code <= 65)                     //Rain (slight 61, moderate 63, heavy 65)
++    {
++        impliedCloud = 90;
++        impliedPrecip   = code === 61 ? 1.0 : code === 63 ? 4.0 : 12.0;
++        impliedSnowfall = 0;
++    }
++    else if (code >= 66 && code <= 67)                     //Freezing rain
++    {
++        impliedCloud = 95;  impliedPrecip = 3.0;  impliedSnowfall = 0;
++    }
++    else if (code >= 71 && code <= 77)                     //Snowfall (slight 71, moderate 73, heavy 75; snow grains 77)
++    {
++        impliedCloud = 90;
++        impliedPrecip   = 0;
++        impliedSnowfall = code === 71 ? 0.5 : code === 73 ? 2.0 : code === 75 ? 5.0 : 0.3;
++    }
++    else if (code >= 80 && code <= 82)                     //Rain showers (slight → violent)
++    {
++        impliedCloud = 80;
++        impliedPrecip   = code === 80 ? 2.0 : code === 81 ? 6.0 : 20.0;
++        impliedSnowfall = 0;
++    }
++    else if (code === 85 || code === 86)                   //Snow showers (slight / heavy)
++    {
++        impliedCloud    = 80;
++        impliedPrecip   = 0;
++        impliedSnowfall = code === 85 ? 1.0 : 4.0;
++    }
++    else if (code === 95)                                  //Thunderstorm (slight / moderate)
++    {
++        impliedCloud = 95;  impliedPrecip = 8.0;  impliedSnowfall = 0;
++    }
++    else if (code === 96 || code === 99)                   //Thunderstorm with hail
++    {
++        impliedCloud = 95;  impliedPrecip = 15.0; impliedSnowfall = 0;
++    }
++
++    //Apply implied values only where no sensor override already set them.
++    if (cloudOverride === null && impliedCloud !== undefined)
++    {
++        w.cloudCover = Math.max(w.cloudCover, impliedCloud);
++    }
++    if (precipOverride === null && impliedPrecip !== undefined)
++    {
++        w.precip = Math.max(w.precip, impliedPrecip);
++    }
++    if (snowOverride === null && impliedSnowfall !== undefined)
++    {
++        w.snowfall = Math.max(w.snowfall, impliedSnowfall);
++    }
++}
++
+ export interface WeatherData
+ {
+     cloudCover:     number;
+@@ -571,9 +672,9 @@ export class HeliosEngine
+             azimuthDeg: number;
+         } | null)[];
+     };
+-    //Per-(canvas, zoom) memo for _sunArcScale so the 8-direction projection probe runs once per size/zoom
++    //Per-(canvas, zoom, arcZoom) memo for _sunArcScale so the 8-direction projection probe runs once per size/zoom
+     //change, not per arc sample per frame. Bearing/pitch invariant, so auto-rotation never refreshes it.
+-    private _arcScaleMemo?: { w: number; h: number; zoom: number; scale: number };
++    private _arcScaleMemo?: { w: number; h: number; zoom: number; arcZoom: number; scale: number };
+     //Memo for getTimelineSeries, keyed on the object references it actually reads: the hourly forecast, the
+     //irradiance-sensor samples and the temperature/humidity override samples. Every scrub tick calls this via
+     //onWeatherUpdate/setSelectedTime, but those references only change on a real fetch/override update (the
+@@ -1107,6 +1208,12 @@ export class HeliosEngine
+             const code  = this._weatherOverrideAt('code',        t); if (code  !== null)
+             {
+                 w.weatherCode = Math.round(code);
++                //When the weather entity overrides the WMO code but no dedicated sensor overrides the
++                //corresponding numeric variables, synthesize implied values so the visual layers (rain
++                //particles, snow flakes, cloud veil) match the declared condition. Without this the
++                //layers read the model's precip/snowfall/cloud which may be 0 (clear day in the forecast)
++                //while the code says "rainy", leaving the map visually unchanged.
++                applyCodeImpliedWeather(w, Math.round(code), cloud, prec, snow);
+             }
+         }
+         return w;
+@@ -1814,9 +1921,9 @@ export class HeliosEngine
+     }
+ 
+     //Dynamic sun-arc radius scale: size the arc so its widest on-screen reach is a fixed fraction of the
+-    //card's smaller side at any size/zoom/home. Measure ground px-per-metre at the home via an 8-direction
+-    //probe circle, taking the max home->point distance (the projected ellipse's semi-major axis, invariant
+-    //to bearing/pitch) so the arc holds steady through auto-rotation. Memoised per (canvas, zoom).
++    //card's smaller side at any size/zoom/home, modulated by user arc-zoom. Measure ground px-per-metre at the
++    //home via an 8-direction probe circle, taking the max home->point distance (the projected ellipse's semi-major axis,
++    //invariant to bearing/pitch) so the arc holds steady through auto-rotation. Memoised per (canvas, zoom, arcZoom).
+     private _sunArcScale(): number
+     {
+         const w = this._cachedCanvasCssW;
+@@ -1824,14 +1931,15 @@ export class HeliosEngine
+         const minDim = Math.min(w || Infinity, h || Infinity);
+         //The scene zoom changes the projected px per metre the probe below measures, so it keys the memo.
+         const zoom = this._renderer ? this._renderer.camera.zoom : -1;
++        const az = arcZoom(this.cfg);
+ 
+         const memo = this._arcScaleMemo;
+-        if (memo && memo.w === w && memo.h === h && memo.zoom === zoom)
++        if (memo && memo.w === w && memo.h === h && memo.zoom === zoom && memo.arcZoom === az)
+         {
+             return memo.scale;
+         }
+ 
+-        let scale = steppedArcScale(minDim);
++        let scale = steppedArcScale(minDim) * az;
+         if (this._renderer && Number.isFinite(minDim) && minDim > 0)
+         {
+             const D          = Math.PI / 180;
+@@ -1868,17 +1976,17 @@ export class HeliosEngine
+                     //Target arc radius as a fraction of the card's smaller side; clamp keeps the disc/halo
+                     //sane and leaves headroom above the apex for the chips on the sun.
+                     const TARGET_FRAC = 0.41;
+-                    const desiredR    = (TARGET_FRAC * minDim) / pxPerM;
++                    const desiredR    = (TARGET_FRAC * az * minDim) / pxPerM;
+                     //Floor and cap are on-screen bounds expressed in metre scale: under a scene zoom the same
+                     //screen reach takes 1/zoom the metres, so both move with it (else a small card on the floor
+                     //would see its arc leave the card at 2x).
+                     const z = zoom > 0 ? zoom : 1;
+-                    scale = Math.max(0.72 / z, Math.min(desiredR / SUN_ARC_RADIUS_M, 6 / z));
++                    scale = Math.max((0.72 * az) / z, Math.min(desiredR / SUN_ARC_RADIUS_M, (6 * az) / z));
+                 }
+             }
+         }
+ 
+-        this._arcScaleMemo = { w, h, zoom, scale };
++        this._arcScaleMemo = { w, h, zoom, arcZoom: az, scale };
+         return scale;
+     }
+     //Public accessor so the card scales the sun disc + halo (and the moon's) with the arc radius (else the disc
+@@ -2524,6 +2632,7 @@ export class HeliosEngine
+         const prevAutoRotateOn = this.cfg['auto-rotate-enabled'] === true;
+         const prevCameraLocked = this.isCameraLocked();
+         const prevZoom         = sceneZoom(this.cfg);
++        const prevArcZoom      = arcZoom(this.cfg);
+         this.cfg = { ...cfg };
+ 
+         //Re-arm the auto-rotate rAF loop when the flags transition back to rotation-permitting (the loop
+@@ -2565,6 +2674,15 @@ export class HeliosEngine
+             this._moonArcInputsCache = undefined;
+         }
+ 
++        //Arc zoom: scales the sun and moon arc radius up or down; drops arc caches so projection passes update.
++        const nextArcZoom = arcZoom(this.cfg);
++        if (nextArcZoom !== prevArcZoom)
++        {
++            this._arcScaleMemo       = undefined;
++            this._arcInputsCache     = undefined;
++            this._moonArcInputsCache = undefined;
++        }
++
+         //Building option updates (radius/count/real-size/height/cluster): re-interpret the cached raw
+         //footprints in memory via _ensureBuildings -> _applyBuildings. The location key is unchanged, so this
+         //never re-fetches the tiles; the renderer re-extrudes from the freshly interpreted Building[]. We always
+diff --git a/test/scene-zoom.test.ts b/test/scene-zoom.test.ts
+index a95b021..8e7e23c 100644
+--- a/test/scene-zoom.test.ts
++++ b/test/scene-zoom.test.ts
+@@ -4,25 +4,56 @@ import { SceneCamera } from '../src/scene/projection';
+ 
+ describe('sceneZoom', () =>
+ {
+-    it('defaults to 1 with no config, an unknown value, or a bad type', () =>
++    it('defaults to 1 with no config, an unknown value, or an out-of-range number', () =>
+     {
+         expect(sceneZoom(undefined)).toBe(1);
+         expect(sceneZoom({} as any)).toBe(1);
+         expect(sceneZoom({ 'scene-zoom': 3 } as any)).toBe(1);
++        expect(sceneZoom({ 'scene-zoom': 0.1 } as any)).toBe(1);
+         expect(sceneZoom({ 'scene-zoom': 'big' } as any)).toBe(1);
+         expect(sceneZoom({ 'scene-zoom': null } as any)).toBe(1);
+     });
+ 
+-    it('accepts the three levels as numbers or as the editor\'s strings', () =>
++    it('accepts numbers or strings within the [0.25, 2] range', () =>
+     {
++        expect(sceneZoom({ 'scene-zoom': 0.25 } as any)).toBe(0.25);
++        expect(sceneZoom({ 'scene-zoom': 0.75 } as any)).toBe(0.75);
+         expect(sceneZoom({ 'scene-zoom': 1.5 } as any)).toBe(1.5);
+         expect(sceneZoom({ 'scene-zoom': 2 } as any)).toBe(2);
++        expect(sceneZoom({ 'scene-zoom': '0.5' } as any)).toBe(0.5);
+         expect(sceneZoom({ 'scene-zoom': '1.5' } as any)).toBe(1.5);
+         expect(sceneZoom({ 'scene-zoom': '2' } as any)).toBe(2);
+         expect(sceneZoom({ 'scene-zoom': '1' } as any)).toBe(1);
+     });
+ });
+ 
++describe('arcZoom', () =>
++{
++    it('defaults to 1 with no config, an unknown value, or an out-of-range number', async () =>
++    {
++        const { arcZoom } = await import('../src/core/config/helios-config');
++        expect(arcZoom(undefined)).toBe(1);
++        expect(arcZoom({} as any)).toBe(1);
++        expect(arcZoom({ 'arc-zoom': 3 } as any)).toBe(1);
++        expect(arcZoom({ 'arc-zoom': 0.1 } as any)).toBe(1);
++        expect(arcZoom({ 'arc-zoom': 'big' } as any)).toBe(1);
++        expect(arcZoom({ 'arc-zoom': null } as any)).toBe(1);
++    });
++
++    it('accepts numbers or strings within the [0.25, 2] range', async () =>
++    {
++        const { arcZoom } = await import('../src/core/config/helios-config');
++        expect(arcZoom({ 'arc-zoom': 0.25 } as any)).toBe(0.25);
++        expect(arcZoom({ 'arc-zoom': 0.75 } as any)).toBe(0.75);
++        expect(arcZoom({ 'arc-zoom': 1.5 } as any)).toBe(1.5);
++        expect(arcZoom({ 'arc-zoom': 2 } as any)).toBe(2);
++        expect(arcZoom({ 'arc-zoom': '0.5' } as any)).toBe(0.5);
++        expect(arcZoom({ 'arc-zoom': '1.5' } as any)).toBe(1.5);
++        expect(arcZoom({ 'arc-zoom': '2' } as any)).toBe(2);
++        expect(arcZoom({ 'arc-zoom': '1' } as any)).toBe(1);
++    });
++});
++
+ describe('SceneCamera under a zoom', () =>
+ {
+     function cam(zoom: number): SceneCamera
+@@ -54,3 +85,47 @@ describe('SceneCamera under a zoom', () =>
+         expect(cam(2).groundTransform(100, 100).transform.endsWith(' scale(2)')).toBe(true);
+     });
+ });
++
++describe('VISUAL_CONFIG_KEYS', () =>
++{
++    it('includes shadow-opacity and shadows-enabled so changes trigger engine updateConfig', async () =>
++    {
++        const { VISUAL_CONFIG_KEYS, computeConfigSig } = await import('../src/card/init');
++        expect(VISUAL_CONFIG_KEYS).toContain('shadow-opacity');
++        expect(VISUAL_CONFIG_KEYS).toContain('shadows-enabled');
++        expect(VISUAL_CONFIG_KEYS).toContain('scene-zoom');
++        expect(VISUAL_CONFIG_KEYS).toContain('arc-zoom');
++        expect(VISUAL_CONFIG_KEYS).toContain('battery-above-arc');
++
++        const sig1 = computeConfigSig({ 'shadow-opacity': 0.32 } as any);
++        const sig2 = computeConfigSig({ 'shadow-opacity': 0.8 } as any);
++        expect(sig1).not.toBe(sig2);
++
++        const sig3 = computeConfigSig({ 'shadows-enabled': true } as any);
++        const sig4 = computeConfigSig({ 'shadows-enabled': false } as any);
++        expect(sig3).not.toBe(sig4);
++
++        const sig5 = computeConfigSig({ 'arc-zoom': 1 } as any);
++        const sig6 = computeConfigSig({ 'arc-zoom': 1.5 } as any);
++        expect(sig5).not.toBe(sig6);
++
++        const sig7 = computeConfigSig({ 'battery-above-arc': false } as any);
++        const sig8 = computeConfigSig({ 'battery-above-arc': true } as any);
++        expect(sig7).not.toBe(sig8);
++    });
++});
++
++describe('batteryAboveArc', () =>
++{
++    it('returns true only when battery-above-arc is strictly true', async () =>
++    {
++        const { batteryAboveArc } = await import('../src/core/config/helios-config');
++        expect(batteryAboveArc(undefined)).toBe(false);
++        expect(batteryAboveArc({} as any)).toBe(false);
++        expect(batteryAboveArc({ 'battery-above-arc': false } as any)).toBe(false);
++        expect(batteryAboveArc({ 'battery-above-arc': 'true' } as any)).toBe(false);
++        expect(batteryAboveArc({ 'battery-above-arc': 1 } as any)).toBe(false);
++        expect(batteryAboveArc({ 'battery-above-arc': true } as any)).toBe(true);
++    });
++});
++

--- a/sandbox/index.html
+++ b/sandbox/index.html
@@ -1,0 +1,437 @@
+<!DOCTYPE html>
+<html lang="fr">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>HELIOS - Test Sandbox</title>
+    <link rel="stylesheet" href="./sandbox.css">
+</head>
+<body>
+    <!-- Top Navigation Header -->
+    <header class="sandbox-header">
+        <div class="brand-badge">
+            <span class="brand-icon">
+                <svg class="sb-icon" viewBox="0 0 24 24"><circle cx="12" cy="12" r="4"/><path d="M12 2v2"/><path d="M12 20v2"/><path d="m4.93 4.93 1.41 1.41"/><path d="m17.66 17.66 1.41 1.41"/><path d="M2 12h2"/><path d="M20 12h2"/><path d="m6.34 17.66-1.41 1.41"/><path d="m19.07 4.93-1.41 1.41"/></svg>
+            </span>
+            <span>HELIOS Sandbox</span>
+            <span class="brand-tag">v2026.9.4</span>
+        </div>
+        <div class="header-controls">
+            <button class="sb-btn" id="btn-reset-cache" title="Vider les caches locaux (OpenStreetMap, météo, etc.)">
+                <svg class="sb-icon" viewBox="0 0 24 24"><path d="M3 6h18"/><path d="M19 6v14c0 1-1 2-2 2H7c-1 0-2-1-2-2V6"/><path d="M8 6V4c0-1 1-2 2-2h4c1 0 2 1 2 2v2"/><line x1="10" x2="10" y1="11" y2="17"/><line x1="14" x2="14" y1="11" y2="17"/></svg>
+                <span>Vider Cache</span>
+            </button>
+            <button class="sb-btn" id="btn-theme-toggle" title="Basculer thème sombre / clair">
+                <svg class="sb-icon" viewBox="0 0 24 24"><path d="M12 3a6 6 0 0 0 9 9 9 9 0 1 1-9-9Z"/></svg>
+                <span>Sombre</span>
+            </button>
+        </div>
+    </header>
+
+    <!-- Main Workspace -->
+    <div class="sandbox-body">
+        <!-- Viewport Controls & Helios Card Preview Stage -->
+        <main class="preview-stage">
+            <div class="stage-viewport-bar">
+                <button class="viewport-btn active" data-viewport="desktop">Desktop (840px)</button>
+                <button class="viewport-btn" data-viewport="tablet">Tablette (600px)</button>
+                <button class="viewport-btn" data-viewport="mobile">Mobile (380px)</button>
+            </div>
+
+            <div class="card-frame viewport-desktop" id="card-frame">
+                <!-- Helios Custom Card Web Component -->
+                <helios-card></helios-card>
+            </div>
+        </main>
+
+        <!-- Sidebar Collapse Toggle Button -->
+        <button class="toggle-sidebar-btn" id="btn-toggle-sidebar" title="Replier/Déplier la barre de réglages">
+            ▶
+        </button>
+
+        <!-- Sidebar Controls & Simulator -->
+        <aside class="sandbox-sidebar" id="sandbox-sidebar">
+            <div class="sidebar-tabs">
+                <button class="sidebar-tab active" data-tab="config">
+                    <svg class="sb-icon" viewBox="0 0 24 24"><path d="M12.22 2h-.44a2 2 0 0 0-2 2v.18a2 2 0 0 1-1 1.73l-.43.25a2 2 0 0 1-2 0l-.15-.08a2 2 0 0 0-2.73.73l-.22.38a2 2 0 0 0 .73 2.73l.15.1a2 2 0 0 1 1 1.72v.51a2 2 0 0 1-1 1.74l-.15.09a2 2 0 0 0-.73 2.73l.22.38a2 2 0 0 0 2.73.73l.15-.08a2 2 0 0 1 2 0l.43.25a2 2 0 0 1 1 1.73V20a2 2 0 0 0 2 2h.44a2 2 0 0 0 2-2v-.18a2 2 0 0 1 1-1.73l.43-.25a2 2 0 0 1 2 0l.15.08a2 2 0 0 0 2.73-.73l.22-.39a2 2 0 0 0-.73-2.73l-.15-.08a2 2 0 0 1-1-1.74v-.5a2 2 0 0 1 1-1.74l.15-.09a2 2 0 0 0 .73-2.73l-.22-.38a2 2 0 0 0-2.73-.73l-.15.08a2 2 0 0 1-2 0l-.43-.25a2 2 0 0 1-1-1.73V4a2 2 0 0 0-2-2z"/><circle cx="12" cy="12" r="3"/></svg>
+                    <span>Réglages Carte</span>
+                </button>
+                <button class="sidebar-tab" data-tab="sim">
+                    <svg class="sb-icon" viewBox="0 0 24 24"><polygon points="13 2 3 14 12 14 11 22 21 10 12 10 13 2"/></svg>
+                    <span>Simulation</span>
+                </button>
+                <button class="sidebar-tab" data-tab="yaml">
+                    <svg class="sb-icon" viewBox="0 0 24 24"><polyline points="16 18 22 12 16 6"/><polyline points="8 6 2 12 8 18"/></svg>
+                    <span>JSON / YAML</span>
+                </button>
+            </div>
+
+            <div class="sidebar-content">
+                <!-- TAB 1: CARD CONFIGURATION -->
+                <div class="tab-pane active" id="tab-config">
+                    <!-- Location Settings -->
+                    <div class="sb-section">
+                        <div class="sb-section-title">
+                            <span>
+                                <svg class="sb-icon" viewBox="0 0 24 24"><path d="M20 10c0 6-8 12-8 12s-8-6-8-12a8 8 0 0 1 16 0Z"/><circle cx="12" cy="10" r="3"/></svg>
+                                <span>Emplacement du Domicile</span>
+                            </span>
+                        </div>
+                        <div style="display: flex; gap: 8px;">
+                            <div class="sb-field" style="flex: 1;">
+                                <label class="sb-label">Latitude</label>
+                                <input type="number" step="0.0001" class="sb-input" id="cfg-lat" value="48.8566">
+                            </div>
+                            <div class="sb-field" style="flex: 1;">
+                                <label class="sb-label">Longitude</label>
+                                <input type="number" step="0.0001" class="sb-input" id="cfg-lon" value="2.3522">
+                            </div>
+                        </div>
+                        <div style="display: flex; flex-wrap: wrap; gap: 4px; margin-bottom: 8px;">
+                            <button class="sb-btn" id="btn-current-location" style="width: 100%; justify-content: center; background: rgba(59, 130, 246, 0.15); border-color: var(--sb-accent); color: var(--sb-text);" title="Utiliser la position GPS de votre navigateur">
+                                <svg class="sb-icon" viewBox="0 0 24 24"><polygon points="3 11 22 2 13 21 11 13 3 11"/></svg>
+                                <span>Ma position actuelle</span>
+                            </button>
+                        </div>
+                        <div style="display: flex; flex-wrap: wrap; gap: 4px;">
+                            <button class="sb-btn city-btn" data-lat="48.8566" data-lon="2.3522">Paris</button>
+                            <button class="sb-btn city-btn" data-lat="43.6047" data-lon="1.4442">Toulouse</button>
+                            <button class="sb-btn city-btn" data-lat="43.2965" data-lon="5.3698">Marseille</button>
+                            <button class="sb-btn city-btn" data-lat="50.6292" data-lon="3.0573">Lille</button>
+                            <button class="sb-btn city-btn" data-lat="45.7640" data-lon="4.8357">Lyon</button>
+                            <button class="sb-btn city-btn" data-lat="52.3676" data-lon="4.9041">Amsterdam</button>
+                        </div>
+                    </div>
+
+                    <!-- Scene & Buildings -->
+                    <div class="sb-section">
+                        <div class="sb-section-title">
+                            <span>
+                                <svg class="sb-icon" viewBox="0 0 24 24"><path d="M6 22V4a2 2 0 0 1 2-2h8a2 2 0 0 1 2 2v18Z"/><path d="M6 12H4a2 2 0 0 0-2 2v6a2 2 0 0 0 2 2h2"/><path d="M18 9h2a2 2 0 0 1 2 2v9a2 2 0 0 1-2 2h-2"/><path d="M10 6h4"/><path d="M10 10h4"/><path d="M10 14h4"/><path d="M10 18h4"/></svg>
+                                <span>Bâtiments & Rendu 3D</span>
+                            </span>
+                        </div>
+
+                        <div class="sb-field">
+                            <div class="sb-field-row">
+                                <span class="sb-label">Rayon d'affichage</span>
+                                <span class="sb-value-badge"><span id="val-cfg-radius">200</span> m</span>
+                            </div>
+                            <input type="range" class="sb-range" id="cfg-radius" min="0" max="250" step="10" value="200">
+                        </div>
+
+                        <div class="sb-field">
+                            <div class="sb-field-row">
+                                <span class="sb-label">Nombre de bâtiments</span>
+                                <span class="sb-value-badge" id="val-cfg-bld-count">50</span>
+                            </div>
+                            <input type="range" class="sb-range" id="cfg-bld-count" min="10" max="100" step="5" value="50">
+                        </div>
+
+                        <div class="sb-field">
+                            <div class="sb-field-row">
+                                <span class="sb-label">Opacité bâtiments voisins</span>
+                                <span class="sb-value-badge"><span id="val-cfg-bld-opacity">50</span>%</span>
+                            </div>
+                            <input type="range" class="sb-range" id="cfg-bld-opacity" min="0" max="100" step="5" value="50">
+                        </div>
+
+                        <div class="sb-field-row">
+                            <span class="sb-label">Hauteurs réelles des bâtiments</span>
+                            <label class="sb-switch">
+                                <input type="checkbox" id="cfg-bld-real-size" checked>
+                                <span class="sb-slider-switch"></span>
+                            </label>
+                        </div>
+
+                        <div class="sb-field-row">
+                            <span class="sb-label">Ombres portées</span>
+                            <label class="sb-switch">
+                                <input type="checkbox" id="cfg-shadows" checked>
+                                <span class="sb-slider-switch"></span>
+                            </label>
+                        </div>
+
+                        <div class="sb-field">
+                            <div class="sb-field-row">
+                                <span class="sb-label">Opacité des ombres</span>
+                                <span class="sb-value-badge"><span id="val-cfg-shadow-opacity">32</span>%</span>
+                            </div>
+                            <input type="range" class="sb-range" id="cfg-shadow-opacity" min="0" max="100" step="2" value="32">
+                        </div>
+
+                        <div class="sb-field-row">
+                            <span class="sb-label" style="display: inline-flex; align-items: center; gap: 6px;">
+                                <svg class="sb-icon" viewBox="0 0 24 24"><path d="m12 3-1.912 5.813a2 2 0 0 1-1.275 1.275L3 12l5.813 1.912a2 2 0 0 1 1.275 1.275L12 21l1.912-5.813a2 2 0 0 1 1.275-1.275L21 12l-5.813-1.912a2 2 0 0 1-1.275-1.275L12 3Z"/><path d="M5 3v4"/><path d="M19 17v4"/><path d="M3 5h4"/><path d="M17 19h4"/></svg>
+                                <span>Effet "Miniature" (Tilt-shift / Vignette)</span>
+                            </span>
+                            <label class="sb-switch">
+                                <input type="checkbox" id="cfg-miniature-blur">
+                                <span class="sb-slider-switch"></span>
+                            </label>
+                        </div>
+
+                        <div class="sb-field" id="cfg-miniature-blur-container" style="display: none;">
+                            <div class="sb-field-row">
+                                <span class="sb-label">Niveau de blur</span>
+                                <span class="sb-value-badge"><span id="val-cfg-miniature-blur">10</span>px</span>
+                            </div>
+                            <input type="range" class="sb-range" id="cfg-miniature-blur-level" min="1" max="30" step="1" value="10">
+
+                            <div class="sb-field-row" style="margin-top: 10px;">
+                                <span class="sb-label">Opacité du vignettage</span>
+                                <span class="sb-value-badge"><span id="val-cfg-miniature-vignette-opacity">50</span>%</span>
+                            </div>
+                            <input type="range" class="sb-range" id="cfg-miniature-vignette-opacity" min="0" max="100" step="5" value="50">
+                        </div>
+                    </div>
+
+                    <!-- Display & Camera -->
+                    <div class="sb-section">
+                        <div class="sb-section-title">
+                            <span>
+                                <svg class="sb-icon" viewBox="0 0 24 24"><path d="m15 12-8.5 8.5c-.83.83-2.17.83-3 0 0 0 0 0 0 0a2.12 2.12 0 0 1 0-3L12 9"/><path d="M17.64 15 22 10.64"/><path d="m20.91 3.26-2.17-2.17a2.1 2.1 0 0 0-3 0L13.5 3.33a2.1 2.1 0 0 0 0 3l.7.7-9.4 9.4a4.12 4.12 0 0 0 0 5.83l.25.25a4.12 4.12 0 0 0 5.83 0l9.4-9.4.7.7a2.1 2.1 0 0 0 3 0l2.23-2.24a2.1 2.1 0 0 0 0-3z"/></svg>
+                                <span>Caméra & Interface</span>
+                            </span>
+                        </div>
+
+                        <div class="sb-field">
+                            <div class="sb-field-row">
+                                <span class="sb-label">Zoom de scène</span>
+                                <span class="sb-value-badge"><span id="val-cfg-zoom">1.00</span>x</span>
+                            </div>
+                            <input type="range" class="sb-range" id="cfg-zoom" min="0.25" max="2" step="0.05" value="1">
+                        </div>
+
+                        <div class="sb-field">
+                            <div class="sb-field-row">
+                                <span class="sb-label">Échelle arc solaire</span>
+                                <span class="sb-value-badge"><span id="val-cfg-arc-zoom">1.00</span>x</span>
+                            </div>
+                            <input type="range" class="sb-range" id="cfg-arc-zoom" min="0.25" max="2" step="0.05" value="1">
+                        </div>
+
+                        <div class="sb-field">
+                            <label class="sb-label">Thème fond de carte</label>
+                            <select class="sb-select" id="cfg-map-mode">
+                                <option value="auto">Auto (Suit le thème)</option>
+                                <option value="dark">Dark (Sombre)</option>
+                                <option value="light">Light (Clair)</option>
+                            </select>
+                        </div>
+
+                        <div class="sb-field-row">
+                            <span class="sb-label">Pills au-dessus de l'arc</span>
+                            <label class="sb-switch">
+                                <input type="checkbox" id="cfg-battery-above-arc">
+                                <span class="sb-slider-switch"></span>
+                            </label>
+                        </div>
+
+                        <div class="sb-field-row">
+                            <span class="sb-label">Rotation automatique</span>
+                            <label class="sb-switch">
+                                <input type="checkbox" id="cfg-auto-rotate">
+                                <span class="sb-slider-switch"></span>
+                            </label>
+                        </div>
+
+                        <div class="sb-field-row">
+                            <span class="sb-label">Verrouiller la vue caméra</span>
+                            <label class="sb-switch">
+                                <input type="checkbox" id="cfg-cam-locked">
+                                <span class="sb-slider-switch"></span>
+                            </label>
+                        </div>
+
+                        <div class="sb-field-row">
+                            <span class="sb-label">Effets météo (ciel, pluie, neige)</span>
+                            <label class="sb-switch">
+                                <input type="checkbox" id="cfg-weather" checked>
+                                <span class="sb-slider-switch"></span>
+                            </label>
+                        </div>
+
+                        <div class="sb-field-row">
+                            <span class="sb-label">Afficher la Timeline</span>
+                            <label class="sb-switch">
+                                <input type="checkbox" id="cfg-timeline" checked>
+                                <span class="sb-slider-switch"></span>
+                            </label>
+                        </div>
+
+                        <div class="sb-field-row">
+                            <span class="sb-label">Panneau de détail (au clic d'un chip)</span>
+                            <label class="sb-switch">
+                                <input type="checkbox" id="cfg-detail-panel" checked>
+                                <span class="sb-slider-switch"></span>
+                            </label>
+                        </div>
+
+                        <div class="sb-field">
+                            <div class="sb-field-row">
+                                <span class="sb-label">Puissance max de référence</span>
+                                <span class="sb-value-badge"><span id="val-cfg-max-power">5000</span> W</span>
+                            </div>
+                            <input type="range" class="sb-range" id="cfg-max-power" min="1000" max="15000" step="500" value="5000">
+                        </div>
+                    </div>
+                </div>
+
+                <!-- TAB 2: LIVE SIMULATION -->
+                <div class="tab-pane" id="tab-sim">
+                    <!-- Quick Presets -->
+                    <div class="sb-section">
+                        <div class="sb-section-title">
+                            <span>
+                                <svg class="sb-icon" viewBox="0 0 24 24"><polygon points="13 2 3 14 12 14 11 22 21 10 12 10 13 2"/></svg>
+                                <span>Scénarios Prédéfinis</span>
+                            </span>
+                        </div>
+                        <div class="preset-grid">
+                            <button class="preset-btn" data-preset="noon_summer">
+                                <strong>
+                                    <svg class="sb-icon" viewBox="0 0 24 24"><circle cx="12" cy="12" r="4"/><path d="M12 2v2"/><path d="M12 20v2"/><path d="m4.93 4.93 1.41 1.41"/><path d="m17.66 17.66 1.41 1.41"/><path d="M2 12h2"/><path d="M20 12h2"/><path d="m6.34 17.66-1.41 1.41"/><path d="m19.07 4.93-1.41 1.41"/></svg>
+                                    <span>Midi Solaire</span>
+                                </strong>
+                                <span>5.6 kW PV, export + charge</span>
+                            </button>
+                            <button class="preset-btn" data-preset="night_discharge">
+                                <strong>
+                                    <svg class="sb-icon" viewBox="0 0 24 24"><path d="M12 3a6 6 0 0 0 9 9 9 9 0 1 1-9-9Z"/></svg>
+                                    <span>Nuit & Batterie</span>
+                                </strong>
+                                <span>0 kW PV, décharge batterie</span>
+                            </button>
+                            <button class="preset-btn" data-preset="storm_import">
+                                <strong>
+                                    <svg class="sb-icon" viewBox="0 0 24 24"><path d="M17.5 19H9a7 7 0 1 1 6.71-9h1.79a4.5 4.5 0 1 1 0 9Z"/><path d="m13 13-3 5h4l-1 4"/></svg>
+                                    <span>Orage & Import</span>
+                                </strong>
+                                <span>Forte conso, import réseau</span>
+                            </button>
+                            <button class="preset-btn" data-preset="winter_snow">
+                                <strong>
+                                    <svg class="sb-icon" viewBox="0 0 24 24"><line x1="2" x2="22" y1="12" y2="12"/><line x1="12" x2="12" y1="2" y2="22"/><path d="m20 16-4-4 4-4"/><path d="m4 8 4 4-4 4"/><path d="m16 4-4 4-4-4"/><path d="m8 20 4-4 4 4"/></svg>
+                                    <span>Hiver Enneigé</span>
+                                </strong>
+                                <span>-2°C, neige, faible PV</span>
+                            </button>
+                        </div>
+                    </div>
+
+                    <!-- Energy Flow Sliders -->
+                    <div class="sb-section">
+                        <div class="sb-section-title">
+                            <span>
+                                <svg class="sb-icon" viewBox="0 0 24 24"><path d="m11 7-3 5h4l-1 5 6-7h-4l1-3Z"/><rect width="16" height="10" x="2" y="7" rx="2"/><line x1="22" x2="22" y1="11" y2="13"/></svg>
+                                <span>Flux Énergétiques en Direct</span>
+                            </span>
+                        </div>
+
+                        <div class="sb-field">
+                            <div class="sb-field-row">
+                                <span class="sb-label">Production PV (Soleil)</span>
+                                <span class="sb-value-badge"><span id="val-solar">3450</span> W</span>
+                            </div>
+                            <input type="range" class="sb-range" id="sim-solar" min="0" max="8000" step="50" value="3450">
+                        </div>
+
+                        <div class="sb-field">
+                            <div class="sb-field-row">
+                                <span class="sb-label">Réseau (+ Import / - Export)</span>
+                                <span class="sb-value-badge"><span id="val-grid">-850</span> W</span>
+                            </div>
+                            <input type="range" class="sb-range" id="sim-grid" min="-6000" max="6000" step="50" value="-850">
+                        </div>
+
+                        <div class="sb-field">
+                            <div class="sb-field-row">
+                                <span class="sb-label">Puissance Batterie (+ Chg / - Dchg)</span>
+                                <span class="sb-value-badge"><span id="val-battery-power">1200</span> W</span>
+                            </div>
+                            <input type="range" class="sb-range" id="sim-battery-power" min="-4000" max="4000" step="50" value="1200">
+                        </div>
+
+                        <div class="sb-field">
+                            <div class="sb-field-row">
+                                <span class="sb-label">Batterie État de Charge (SoC)</span>
+                                <span class="sb-value-badge"><span id="val-battery-soc">78</span> %</span>
+                            </div>
+                            <input type="range" class="sb-range" id="sim-battery-soc" min="0" max="100" step="1" value="78">
+                        </div>
+                    </div>
+
+                    <!-- Weather & Environment -->
+                    <div class="sb-section">
+                        <div class="sb-section-title">
+                            <span>
+                                <svg class="sb-icon" viewBox="0 0 24 24"><path d="M12 2v2"/><path d="m4.93 4.93 1.41 1.41"/><path d="M20 12h2"/><path d="m19.07 4.93-1.41 1.41"/><path d="M15.947 12.65a4 4 0 0 0-5.925-4.128"/><path d="M13 22H7a5 5 0 1 1 4.9-6H13a3 3 0 0 1 0 6Z"/></svg>
+                                <span>Météo & Climat Local</span>
+                            </span>
+                        </div>
+
+                        <div class="sb-field">
+                            <label class="sb-label">Condition météo</label>
+                            <select class="sb-select" id="sim-weather">
+                                <option value="sunny">Ensoleillé (Sunny)</option>
+                                <option value="partlycloudy">Éclaircies (Partly Cloudy)</option>
+                                <option value="cloudy">Nuageux (Cloudy)</option>
+                                <option value="rainy">Pluie (Rain)</option>
+                                <option value="pouring">Forte Pluie (Pouring)</option>
+                                <option value="snowy">Chutes de neige (Snow)</option>
+                                <option value="lightning-rainy">Orage violent (Lightning & Rain)</option>
+                            </select>
+                        </div>
+
+                        <div class="sb-field">
+                            <div class="sb-field-row">
+                                <span class="sb-label">Température extérieure</span>
+                                <span class="sb-value-badge"><span id="val-temp">21.5</span> °C</span>
+                            </div>
+                            <input type="range" class="sb-range" id="sim-temp" min="-15" max="42" step="0.5" value="21.5">
+                        </div>
+
+                        <div class="sb-field">
+                            <div class="sb-field-row">
+                                <span class="sb-label">Humidité relative</span>
+                                <span class="sb-value-badge"><span id="val-humidity">55</span> %</span>
+                            </div>
+                            <input type="range" class="sb-range" id="sim-humidity" min="10" max="100" step="1" value="55">
+                        </div>
+                    </div>
+                </div>
+
+                <!-- TAB 3: CONFIGURATION EDITOR -->
+                <div class="tab-pane" id="tab-yaml">
+                    <div class="sb-section">
+                        <div class="sb-section-title">
+                            <span>
+                                <svg class="sb-icon" viewBox="0 0 24 24"><path d="M14.5 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V7.5L14.5 2z"/><polyline points="14 2 14 8 20 8"/><line x1="16" x2="8" y1="13" y2="13"/><line x1="16" x2="8" y1="17" y2="17"/><line x1="10" x2="8" y1="9" y2="9"/></svg>
+                                <span>Configuration JSON / YAML</span>
+                            </span>
+                        </div>
+                        <p class="sb-label-sub">
+                            Vous pouvez modifier directement la configuration brute ci-dessous et l'appliquer à la carte.
+                        </p>
+                        <textarea class="yaml-textarea" id="yaml-editor" spellcheck="false"></textarea>
+                        <div style="display: flex; gap: 8px;">
+                            <button class="sb-btn primary" id="btn-apply-yaml" style="flex: 1;">
+                                <svg class="sb-icon" viewBox="0 0 24 24"><polyline points="20 6 9 17 4 12"/></svg>
+                                <span>Appliquer Configuration</span>
+                            </button>
+                            <button class="sb-btn" id="btn-reset-yaml">
+                                <svg class="sb-icon" viewBox="0 0 24 24"><path d="M3 12a9 9 0 1 0 9-9 9.75 9.75 0 0 0-6.74 2.74L3 8"/><path d="M3 3v5h5"/></svg>
+                                <span>Réinitialiser</span>
+                            </button>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </aside>
+    </div>
+
+    <!-- Script Entrypoint -->
+    <script type="module" src="./sandbox-app.ts"></script>
+</body>
+</html>

--- a/sandbox/mock-hass.ts
+++ b/sandbox/mock-hass.ts
@@ -1,0 +1,533 @@
+import type { HassLike, HassEntity, HassConfig, UnsubscribeFunc } from '../src/core/ha-types';
+import type { HeliosConfig } from '../src/core/config/helios-config';
+
+export interface SandboxSimState {
+    solarPower: number; // Watts
+    gridPower: number; // Watts (+ = import, - = export)
+    batteryPower: number; // Watts (+ = charge, - = discharge)
+    batterySoc: number; // 0..100 %
+    temperature: number; // °C
+    humidity: number; // %
+    weatherCondition: string; // sunny, cloudy, rainy, snowy, lightning
+}
+
+export class MockHassManager {
+    public simState: SandboxSimState = {
+        solarPower: 3450,
+        gridPower: -850,
+        batteryPower: 1200,
+        batterySoc: 78,
+        temperature: 21.5,
+        humidity: 55,
+        weatherCondition: 'sunny',
+    };
+
+    public config: HassConfig = {
+        time_zone: Intl.DateTimeFormat().resolvedOptions().timeZone || 'Europe/Paris',
+        latitude: 48.8566,
+        longitude: 2.3522,
+        elevation: 35,
+        currency: '€',
+        unit_system: {
+            temperature: '°C',
+        },
+    };
+
+    public language = 'fr';
+    public darkMode = true;
+
+    private _listeners: Set<() => void> = new Set();
+    private _eventListeners: Map<string, Set<(ev: unknown) => void>> = new Map();
+
+    public onChange(fn: () => void): () => void {
+        this._listeners.add(fn);
+        return () => this._listeners.delete(fn);
+    }
+
+    private _notify(): void {
+        for (const fn of this._listeners) {
+            try {
+                fn();
+            } catch (e) {
+                console.error('Error in MockHass listener:', e);
+            }
+        }
+    }
+
+    public updateSimState(partial: Partial<SandboxSimState>): void {
+        Object.assign(this.simState, partial);
+        this._notify();
+    }
+
+    public updateConfig(partial: Partial<HassConfig>): void {
+        Object.assign(this.config, partial);
+        this._notify();
+    }
+
+    public setDarkMode(dark: boolean): void {
+        this.darkMode = dark;
+        this._notify();
+    }
+
+    public setLanguage(lang: string): void {
+        this.language = lang;
+        this._notify();
+    }
+
+    public triggerEnergyPrefsUpdated(): void {
+        const cbs = this._eventListeners.get('energy_preferences_updated');
+        if (cbs) {
+            for (const cb of cbs) {
+                cb({});
+            }
+        }
+    }
+
+    public createHassObject(): HassLike {
+        const nowIso = new Date().toISOString();
+
+        const states: Record<string, HassEntity> = {
+            'sensor.solar_production': {
+                entity_id: 'sensor.solar_production',
+                state: String(Math.round(this.simState.solarPower)),
+                attributes: {
+                    unit_of_measurement: 'W',
+                    device_class: 'power',
+                    friendly_name: 'Production Solaire',
+                },
+                last_changed: nowIso,
+                last_updated: nowIso,
+            },
+            'sensor.solar_energy_total': {
+                entity_id: 'sensor.solar_energy_total',
+                state: '18.4',
+                attributes: {
+                    unit_of_measurement: 'kWh',
+                    device_class: 'energy',
+                    state_class: 'total_increasing',
+                    friendly_name: 'Énergie Solaire Totale',
+                },
+                last_changed: nowIso,
+                last_updated: nowIso,
+            },
+            'sensor.grid_power': {
+                entity_id: 'sensor.grid_power',
+                state: String(Math.round(this.simState.gridPower)),
+                attributes: {
+                    unit_of_measurement: 'W',
+                    device_class: 'power',
+                    friendly_name: 'Puissance Réseau',
+                },
+                last_changed: nowIso,
+                last_updated: nowIso,
+            },
+            'sensor.grid_import_total': {
+                entity_id: 'sensor.grid_import_total',
+                state: '4.2',
+                attributes: {
+                    unit_of_measurement: 'kWh',
+                    device_class: 'energy',
+                    state_class: 'total_increasing',
+                    friendly_name: 'Import Réseau',
+                },
+                last_changed: nowIso,
+                last_updated: nowIso,
+            },
+            'sensor.grid_export_total': {
+                entity_id: 'sensor.grid_export_total',
+                state: '6.8',
+                attributes: {
+                    unit_of_measurement: 'kWh',
+                    device_class: 'energy',
+                    state_class: 'total_increasing',
+                    friendly_name: 'Export Réseau',
+                },
+                last_changed: nowIso,
+                last_updated: nowIso,
+            },
+            'sensor.battery_power': {
+                entity_id: 'sensor.battery_power',
+                state: String(Math.round(this.simState.batteryPower)),
+                attributes: {
+                    unit_of_measurement: 'W',
+                    device_class: 'power',
+                    friendly_name: 'Puissance Batterie',
+                },
+                last_changed: nowIso,
+                last_updated: nowIso,
+            },
+            'sensor.battery_soc': {
+                entity_id: 'sensor.battery_soc',
+                state: String(Math.round(this.simState.batterySoc)),
+                attributes: {
+                    unit_of_measurement: '%',
+                    device_class: 'battery',
+                    friendly_name: 'Batterie SoC',
+                },
+                last_changed: nowIso,
+                last_updated: nowIso,
+            },
+            'sensor.battery_charge_total': {
+                entity_id: 'sensor.battery_charge_total',
+                state: '5.1',
+                attributes: {
+                    unit_of_measurement: 'kWh',
+                    device_class: 'energy',
+                    state_class: 'total_increasing',
+                    friendly_name: 'Charge Batterie',
+                },
+                last_changed: nowIso,
+                last_updated: nowIso,
+            },
+            'sensor.battery_discharge_total': {
+                entity_id: 'sensor.battery_discharge_total',
+                state: '3.4',
+                attributes: {
+                    unit_of_measurement: 'kWh',
+                    device_class: 'energy',
+                    state_class: 'total_increasing',
+                    friendly_name: 'Décharge Batterie',
+                },
+                last_changed: nowIso,
+                last_updated: nowIso,
+            },
+            'sensor.outdoor_temperature': {
+                entity_id: 'sensor.outdoor_temperature',
+                state: this.simState.temperature.toFixed(1),
+                attributes: {
+                    unit_of_measurement: '°C',
+                    device_class: 'temperature',
+                    friendly_name: 'Température Extérieure',
+                },
+                last_changed: nowIso,
+                last_updated: nowIso,
+            },
+            'sensor.outdoor_humidity': {
+                entity_id: 'sensor.outdoor_humidity',
+                state: String(Math.round(this.simState.humidity)),
+                attributes: {
+                    unit_of_measurement: '%',
+                    device_class: 'humidity',
+                    friendly_name: 'Humidité Extérieure',
+                },
+                last_changed: nowIso,
+                last_updated: nowIso,
+            },
+            'sensor.device_ev_charger': {
+                entity_id: 'sensor.device_ev_charger',
+                state: '1800',
+                attributes: {
+                    unit_of_measurement: 'W',
+                    device_class: 'power',
+                    friendly_name: 'Borne VE',
+                    icon: 'mdi:car-electric',
+                },
+                last_changed: nowIso,
+                last_updated: nowIso,
+            },
+            'sensor.device_heatpump': {
+                entity_id: 'sensor.device_heatpump',
+                state: '850',
+                attributes: {
+                    unit_of_measurement: 'W',
+                    device_class: 'power',
+                    friendly_name: 'Pompe à Chaleur',
+                    icon: 'mdi:heat-pump',
+                },
+                last_changed: nowIso,
+                last_updated: nowIso,
+            },
+            'sensor.device_water_heater': {
+                entity_id: 'sensor.device_water_heater',
+                state: '0',
+                attributes: {
+                    unit_of_measurement: 'W',
+                    device_class: 'power',
+                    friendly_name: 'Chauffe-eau',
+                    icon: 'mdi:water-boiler',
+                },
+                last_changed: nowIso,
+                last_updated: nowIso,
+            },
+            'weather.home': {
+                entity_id: 'weather.home',
+                state: this.simState.weatherCondition,
+                attributes: {
+                    temperature: this.simState.temperature,
+                    humidity: this.simState.humidity,
+                    friendly_name: 'Météo Locale',
+                },
+                last_changed: nowIso,
+                last_updated: nowIso,
+            },
+        };
+
+        const subscribeEvents = async <T = unknown>(callback: (ev: T) => void, eventType: string): Promise<UnsubscribeFunc> => {
+            if (!this._eventListeners.has(eventType)) {
+                this._eventListeners.set(eventType, new Set());
+            }
+            const set = this._eventListeners.get(eventType)!;
+            const cb = callback as (ev: unknown) => void;
+            set.add(cb);
+            return () => {
+                set.delete(cb);
+            };
+        };
+
+        const callWS = async <T>(payload: { type: string; [k: string]: unknown }): Promise<T> => {
+            const type = payload.type;
+
+            if (type === 'energy/get_prefs') {
+                return {
+                    energy_sources: [
+                        {
+                            type: 'solar',
+                            stat_energy_from: 'sensor.solar_energy_total',
+                            stat_rate: 'sensor.solar_production',
+                        },
+                        {
+                            type: 'grid',
+                            name: 'Réseau Enedis',
+                            stat_energy_from: 'sensor.grid_import_total',
+                            stat_energy_to: 'sensor.grid_export_total',
+                            stat_rate: 'sensor.grid_power',
+                            flow_from: [
+                                {
+                                    stat_energy_from: 'sensor.grid_import_total',
+                                    number_energy_price: 0.2516,
+                                    stat_cost: 'sensor.grid_import_total_cost',
+                                },
+                            ],
+                            flow_to: [
+                                {
+                                    stat_energy_to: 'sensor.grid_export_total',
+                                    number_energy_price: 0.13,
+                                    stat_compensation: 'sensor.grid_export_total_compensation',
+                                },
+                            ],
+                        },
+                        {
+                            type: 'battery',
+                            name: 'Batterie Domestique',
+                            stat_energy_from: 'sensor.battery_discharge_total',
+                            stat_energy_to: 'sensor.battery_charge_total',
+                            power_config: {
+                                stat_rate_inverted: 'sensor.battery_power',
+                            },
+                            stat_soc: 'sensor.battery_soc',
+                        },
+                    ],
+                    device_consumption: [
+                        {
+                            stat_consumption: 'sensor.device_ev_charger_kwh',
+                            stat_rate: 'sensor.device_ev_charger',
+                            name: 'Borne VE',
+                        },
+                        {
+                            stat_consumption: 'sensor.device_heatpump_kwh',
+                            stat_rate: 'sensor.device_heatpump',
+                            name: 'Pompe à Chaleur',
+                        },
+                        {
+                            stat_consumption: 'sensor.device_water_heater_kwh',
+                            stat_rate: 'sensor.device_water_heater',
+                            name: 'Chauffe-eau',
+                        },
+                    ],
+                } as unknown as T;
+            }
+
+            if (type === 'energy/info') {
+                return {
+                    cost_sensors: {
+                        'sensor.grid_import_total': 'sensor.grid_import_total_cost',
+                        'sensor.grid_export_total': 'sensor.grid_export_total_compensation',
+                    },
+                } as unknown as T;
+            }
+
+            if (type === 'recorder/statistics_during_period') {
+                const startTime = new Date(payload.start_time as string).getTime();
+                const endTime = new Date(payload.end_time as string).getTime();
+                const statisticIds = (payload.statistic_ids as string[]) || [];
+                const types = (payload.types as string[]) || ['change'];
+                const period = (payload.period as string) || 'hour';
+
+                let stepMs = 3600 * 1000;
+                if (period === '5minute') stepMs = 5 * 60 * 1000;
+                if (period === 'day') stepMs = 24 * 3600 * 1000;
+
+                const result: Record<string, Record<string, unknown>[]> = {};
+
+                for (const statId of statisticIds) {
+                    const buckets: Record<string, unknown>[] = [];
+                    for (let t = startTime; t < endTime; t += stepMs) {
+                        const bEnd = Math.min(t + stepMs, endTime);
+                        const d = new Date(t);
+                        const hour = d.getHours() + d.getMinutes() / 60;
+
+                        const bucket: Record<string, unknown> = {
+                            start: t,
+                            end: bEnd,
+                        };
+
+                        if (types.includes('change')) {
+                            let changeKwh = 0;
+                            if (statId.includes('solar')) {
+                                if (hour >= 7 && hour <= 20) {
+                                    const peak = 4.5;
+                                    const factor = Math.sin(((hour - 7) / 13) * Math.PI);
+                                    changeKwh = (peak * factor * (stepMs / 3600000)) * (0.8 + 0.4 * Math.sin(t / 1000000));
+                                }
+                            } else if (statId.includes('grid_import')) {
+                                const baseImport = (hour < 7 || hour > 19) ? 0.6 : 0.2;
+                                changeKwh = baseImport * (stepMs / 3600000) * (0.9 + 0.2 * Math.cos(t / 800000));
+                            } else if (statId.includes('grid_export')) {
+                                if (hour >= 11 && hour <= 16) {
+                                    changeKwh = 1.2 * (stepMs / 3600000);
+                                }
+                            } else if (statId.includes('battery_charge')) {
+                                if (hour >= 9 && hour <= 13) {
+                                    changeKwh = 1.5 * (stepMs / 3600000);
+                                }
+                            } else if (statId.includes('battery_discharge')) {
+                                if (hour >= 19 && hour <= 23) {
+                                    changeKwh = 0.8 * (stepMs / 3600000);
+                                }
+                            } else if (statId.includes('device')) {
+                                changeKwh = 0.3 * (stepMs / 3600000);
+                            }
+                            bucket.change = Math.max(0, changeKwh);
+                        }
+
+                        if (types.includes('mean')) {
+                            if (statId.includes('temperature')) {
+                                bucket.mean = this.simState.temperature;
+                            } else if (statId.includes('humidity')) {
+                                bucket.mean = this.simState.humidity;
+                            } else if (statId.includes('soc')) {
+                                bucket.mean = this.simState.batterySoc;
+                            } else if (statId.includes('grid_power')) {
+                                bucket.mean = this.simState.gridPower;
+                            } else if (statId.includes('battery_power')) {
+                                bucket.mean = this.simState.batteryPower;
+                            } else {
+                                bucket.mean = 0;
+                            }
+                        }
+
+                        if (types.includes('min') || types.includes('max')) {
+                            if (statId.includes('grid_power')) {
+                                bucket.min = -3000;
+                                bucket.max = 3000;
+                            } else if (statId.includes('battery_power')) {
+                                bucket.min = -2500;
+                                bucket.max = 2500;
+                            } else {
+                                bucket.min = 0;
+                                bucket.max = 100;
+                            }
+                        }
+
+                        buckets.push(bucket);
+                    }
+                    result[statId] = buckets;
+                }
+
+                return result as unknown as T;
+            }
+
+            if (type === 'history/history_during_period') {
+                const entityIds = (payload.entity_ids as string[]) || [];
+                const now = new Date();
+                const result: Record<string, unknown[]> = {};
+                for (const id of entityIds) {
+                    let sVal = '0';
+                    if (id.includes('temperature')) sVal = this.simState.temperature.toFixed(1);
+                    else if (id.includes('humidity')) sVal = String(Math.round(this.simState.humidity));
+                    else if (id.includes('weather')) sVal = this.simState.weatherCondition;
+                    else if (id.includes('soc')) sVal = String(Math.round(this.simState.batterySoc));
+
+                    result[id] = [
+                        {
+                            s: sVal,
+                            lu: (now.getTime() - 3600000) / 1000,
+                        },
+                        {
+                            s: sVal,
+                            lu: now.getTime() / 1000,
+                        },
+                    ];
+                }
+                return result as unknown as T;
+            }
+
+            if (type === 'helios_forecast/series' || type === 'energy/solar_forecast') {
+                const now = new Date();
+                const forecast: Record<string, number> = {};
+                for (let h = 0; h < 48; h++) {
+                    const t = new Date(now.getTime() + h * 3600 * 1000);
+                    t.setMinutes(0, 0, 0);
+                    const hour = t.getHours();
+                    let w = 0;
+                    if (hour >= 7 && hour <= 20) {
+                        w = Math.round(3800 * Math.sin(((hour - 7) / 13) * Math.PI));
+                    }
+                    forecast[t.toISOString()] = w;
+                }
+                return {
+                    wh_hours: forecast,
+                } as unknown as T;
+            }
+
+            return {} as unknown as T;
+        };
+
+        return {
+            states,
+            config: this.config,
+            connection: {
+                subscribeEvents,
+            },
+            callWS,
+            language: this.language,
+            locale: {
+                language: this.language,
+                time_format: '24',
+            },
+            themes: {
+                darkMode: this.darkMode,
+            },
+            user: {
+                is_admin: true,
+            },
+        };
+    }
+}
+
+export const defaultSandboxConfig: HeliosConfig = {
+    'home-latitude': 48.8566,
+    'home-longitude': 2.3522,
+    'display-radius': 200,
+    'building-count': 50,
+    'building-opacity': 0.5,
+    'building-real-size': true,
+    'shadows-enabled': true,
+    'shadow-opacity': 0.32,
+    'show-timeline': true,
+    'show-detail-panel': true,
+    'weather-enabled': true,
+    'auto-rotate-enabled': false,
+    'camera-locked': false,
+    'scene-zoom': '1',
+    'arc-zoom': 1,
+    'battery-above-arc': false,
+    'value-decimals': 1,
+    'max-expected-power': 5000,
+    'map-theme-mode': 'auto',
+    'temperature-entity': 'sensor.outdoor_temperature',
+    'humidity-entity': 'sensor.outdoor_humidity',
+    'weather-entity': 'weather.home',
+    'show-temperature': true,
+    'show-humidity': true,
+};

--- a/sandbox/sandbox-app.ts
+++ b/sandbox/sandbox-app.ts
@@ -1,0 +1,830 @@
+import '../src/helios-card';
+import { HeliosCard } from '../src/helios-card';
+import { HeliosEngine } from '../src/scene/helios-engine';
+import { MockHassManager, defaultSandboxConfig, type SandboxSimState } from './mock-hass';
+import type { HeliosConfig } from '../src/core/config/helios-config';
+
+const STORAGE_KEY_CONFIG = 'helios_sandbox_config';
+const STORAGE_KEY_SIM = 'helios_sandbox_sim';
+const STORAGE_KEY_UI = 'helios_sandbox_ui';
+
+// ══════════════════════════════════════════════════════════════════════════════
+// Sandbox-only overrides (monkey-patches on HeliosEngine prototype)
+// These replicate features from the development patch without modifying src/.
+// ══════════════════════════════════════════════════════════════════════════════
+
+const DEFAULT_ARC_ZOOM  = 1;
+const MIN_ARC_ZOOM      = 0.25;
+const MAX_ARC_ZOOM      = 2;
+const MIN_SCENE_ZOOM    = 0.25;
+const MAX_SCENE_ZOOM    = 2;
+const DEFAULT_SCENE_ZOOM = 1;
+
+/** Read arc-zoom from config (continuous [0.25, 2], default 1). */
+function readArcZoom(config: HeliosConfig | undefined): number {
+    const raw = config?.['arc-zoom' as keyof HeliosConfig];
+    const n = typeof raw === 'number' ? raw : typeof raw === 'string' ? Number(raw) : NaN;
+    return Number.isFinite(n) && n >= MIN_ARC_ZOOM && n <= MAX_ARC_ZOOM ? n : DEFAULT_ARC_ZOOM;
+}
+
+/** Read scene-zoom as a continuous value [0.25, 2] instead of the original discrete [1, 1.5, 2]. */
+function continuousSceneZoom(config: HeliosConfig | undefined): number {
+    const raw = config?.['scene-zoom' as keyof HeliosConfig];
+    const n = typeof raw === 'number' ? raw : typeof raw === 'string' ? Number(raw) : NaN;
+    return Number.isFinite(n) && n >= MIN_SCENE_ZOOM && n <= MAX_SCENE_ZOOM ? n : DEFAULT_SCENE_ZOOM;
+}
+
+// ── Patch _sunArcScale: multiply the base arc scale by the arc-zoom factor ──
+// Mathematically equivalent to the full src/ patch: max(a,min(b,c))*k === max(a*k,min(b*k,c*k)) for k>0.
+const _origSunArcScale = (HeliosEngine.prototype as any)._sunArcScale;
+(HeliosEngine.prototype as any)._sunArcScale = function (): number {
+    const az = readArcZoom(this.cfg);
+    return _origSunArcScale.call(this) * az;
+};
+
+// ── Patch updateConfig: continuous scene-zoom + arc-zoom cache invalidation ──
+const _origUpdateConfig = HeliosEngine.prototype.updateConfig;
+HeliosEngine.prototype.updateConfig = function (cfg: HeliosConfig): void {
+    const prevCZ = continuousSceneZoom(this.cfg);
+    const prevAZ = readArcZoom(this.cfg);
+
+    _origUpdateConfig.call(this, cfg);
+
+    const nextCZ = continuousSceneZoom(this.cfg);
+    const nextAZ = readArcZoom(this.cfg);
+    const renderer = (this as any)._renderer;
+
+    // Continuous scene-zoom: the original only detects discrete [1, 1.5, 2] transitions;
+    // apply the continuous value so intermediate slider positions take effect.
+    if (nextCZ !== prevCZ && renderer) {
+        renderer.setZoom(nextCZ);
+        (this as any)._arcScaleMemo       = undefined;
+        (this as any)._arcInputsCache     = undefined;
+        (this as any)._moonArcInputsCache = undefined;
+        renderer.scheduleRedraw();
+    }
+
+    // Arc-zoom: invalidate the arc projection caches so the next frame recomputes
+    // with the new multiplier.
+    if (nextAZ !== prevAZ) {
+        (this as any)._arcScaleMemo       = undefined;
+        (this as any)._arcInputsCache     = undefined;
+        (this as any)._moonArcInputsCache = undefined;
+        if (renderer) renderer.scheduleRedraw();
+    }
+};
+
+// ══════════════════════════════════════════════════════════════════════════════
+
+interface SandboxUIState {
+    darkMode: boolean;
+    sidebarCollapsed: boolean;
+    activeTab: string;
+    viewport: string;
+    miniatureBlurEnabled: boolean;
+    miniatureBlurLevel: number;
+    miniatureVignetteOpacity: number;
+}
+
+class SandboxApp {
+    private _hassManager = new MockHassManager();
+    private _config: HeliosConfig = { ...defaultSandboxConfig };
+    private _cardElement: HeliosCard | null = null;
+    private _sidebarCollapsed = false;
+    private _miniatureBlurEnabled = false;
+    private _miniatureBlurLevel = 10;
+    private _miniatureVignetteOpacity = 50;
+    private _activeTab = 'config';
+    private _activeViewport = 'desktop';
+
+    public init(): void {
+        this._cardElement = document.querySelector('helios-card') as HeliosCard;
+        if (!this._cardElement) {
+            console.error('Helios card element not found in DOM');
+            return;
+        }
+
+        // Restore saved states from localStorage if present
+        this._loadSavedState();
+
+        // Connect mock Hass and initial config
+        this._cardElement.setConfig(this._config);
+        this._cardElement.hass = this._hassManager.createHassObject();
+
+        // Listen for Hass state changes
+        this._hassManager.onChange(() => {
+            if (this._cardElement) {
+                this._cardElement.hass = this._hassManager.createHassObject();
+                this._cardElement.requestUpdate();
+            }
+        });
+
+        this._bindUI();
+        this._restoreSavedUI();
+        this._updateConfigUI();
+        this._updateSimUI();
+        this._syncYamlUI();
+        this._syncMiniatureVignette();
+        this._syncShadowDOMOverrides();
+    }
+
+    private _loadSavedState(): void {
+        try {
+            // 1. Config
+            const savedConfig = localStorage.getItem(STORAGE_KEY_CONFIG);
+            if (savedConfig) {
+                const parsedConfig = JSON.parse(savedConfig);
+                this._config = { ...defaultSandboxConfig, ...parsedConfig };
+                // Also sync coordinates to hassManager config if present
+                if (typeof this._config['home-latitude'] === 'number' && typeof this._config['home-longitude'] === 'number') {
+                    this._hassManager.updateConfig({
+                        latitude: this._config['home-latitude'],
+                        longitude: this._config['home-longitude'],
+                    });
+                }
+            }
+
+            // 2. SimState
+            const savedSim = localStorage.getItem(STORAGE_KEY_SIM);
+            if (savedSim) {
+                const parsedSim = JSON.parse(savedSim);
+                this._hassManager.updateSimState(parsedSim);
+            }
+
+            // 3. UI State
+            const savedUI = localStorage.getItem(STORAGE_KEY_UI);
+            if (savedUI) {
+                const ui: Partial<SandboxUIState> = JSON.parse(savedUI);
+                if (typeof ui.darkMode === 'boolean') {
+                    this._hassManager.setDarkMode(ui.darkMode);
+                }
+                if (typeof ui.sidebarCollapsed === 'boolean') {
+                    this._sidebarCollapsed = ui.sidebarCollapsed;
+                }
+                if (typeof ui.miniatureBlurEnabled === 'boolean') {
+                    this._miniatureBlurEnabled = ui.miniatureBlurEnabled;
+                }
+                if (typeof ui.miniatureBlurLevel === 'number') {
+                    this._miniatureBlurLevel = ui.miniatureBlurLevel;
+                }
+                if (typeof ui.miniatureVignetteOpacity === 'number') {
+                    this._miniatureVignetteOpacity = ui.miniatureVignetteOpacity;
+                }
+                if (ui.activeTab) {
+                    this._activeTab = ui.activeTab;
+                }
+                if (ui.viewport) {
+                    this._activeViewport = ui.viewport;
+                }
+            }
+        } catch (e) {
+            console.warn('Failed to load sandbox saved state from localStorage:', e);
+        }
+    }
+
+    private _saveConfigState(): void {
+        try {
+            localStorage.setItem(STORAGE_KEY_CONFIG, JSON.stringify(this._config));
+        } catch (e) {
+            console.warn('Failed to save config to localStorage:', e);
+        }
+    }
+
+    private _saveSimState(): void {
+        try {
+            localStorage.setItem(STORAGE_KEY_SIM, JSON.stringify(this._hassManager.simState));
+        } catch (e) {
+            console.warn('Failed to save simState to localStorage:', e);
+        }
+    }
+
+    private _saveUIState(): void {
+        try {
+            const uiState: SandboxUIState = {
+                darkMode: this._hassManager.darkMode,
+                sidebarCollapsed: this._sidebarCollapsed,
+                activeTab: this._activeTab,
+                viewport: this._activeViewport,
+                miniatureBlurEnabled: this._miniatureBlurEnabled,
+                miniatureBlurLevel: this._miniatureBlurLevel,
+                miniatureVignetteOpacity: this._miniatureVignetteOpacity,
+            };
+            localStorage.setItem(STORAGE_KEY_UI, JSON.stringify(uiState));
+        } catch (e) {
+            console.warn('Failed to save UI state to localStorage:', e);
+        }
+    }
+
+    private _restoreSavedUI(): void {
+        // Theme
+        const isDark = this._hassManager.darkMode;
+        document.body.classList.toggle('light-theme', !isDark);
+        const btnTheme = document.getElementById('btn-theme-toggle');
+        if (btnTheme) {
+            btnTheme.innerHTML = isDark
+                ? '<svg class="sb-icon" viewBox="0 0 24 24"><path d="M12 3a6 6 0 0 0 9 9 9 9 0 1 1-9-9Z"/></svg><span>Sombre</span>'
+                : '<svg class="sb-icon" viewBox="0 0 24 24"><circle cx="12" cy="12" r="4"/><path d="M12 2v2"/><path d="M12 20v2"/><path d="m4.93 4.93 1.41 1.41"/><path d="m17.66 17.66 1.41 1.41"/><path d="M2 12h2"/><path d="M20 12h2"/><path d="m6.34 17.66-1.41 1.41"/><path d="m19.07 4.93-1.41 1.41"/></svg><span>Clair</span>';
+        }
+
+        // Sidebar
+        const sidebar = document.getElementById('sandbox-sidebar');
+        const toggleBtn = document.getElementById('btn-toggle-sidebar');
+        if (sidebar && toggleBtn) {
+            sidebar.classList.toggle('collapsed', this._sidebarCollapsed);
+            toggleBtn.classList.toggle('collapsed', this._sidebarCollapsed);
+            toggleBtn.textContent = this._sidebarCollapsed ? '◀' : '▶';
+        }
+
+        // Tabs
+        const tabs = document.querySelectorAll<HTMLButtonElement>('.sidebar-tab');
+        const panes = document.querySelectorAll<HTMLElement>('.tab-pane');
+        tabs.forEach((t) => t.classList.toggle('active', t.dataset.tab === this._activeTab));
+        panes.forEach((p) => p.classList.toggle('active', p.id === `tab-${this._activeTab}`));
+
+        // Viewport
+        const frame = document.getElementById('card-frame');
+        document.querySelectorAll<HTMLButtonElement>('.viewport-btn').forEach((b) => {
+            b.classList.toggle('active', b.dataset.viewport === this._activeViewport);
+        });
+        if (frame) {
+            frame.classList.remove('viewport-desktop', 'viewport-tablet', 'viewport-mobile');
+            frame.classList.add(`viewport-${this._activeViewport}`);
+        }
+    }
+
+    private _syncMiniatureVignette(): void {
+        if (!this._cardElement) return;
+        const shadow = this._cardElement.shadowRoot;
+        if (!shadow) {
+            requestAnimationFrame(() => this._syncMiniatureVignette());
+            return;
+        }
+
+        const blurPx = Math.max(0, this._miniatureBlurLevel);
+        const vignetteAlpha = Math.max(0, Math.min(1, this._miniatureVignetteOpacity / 100));
+
+        // Ensure the CSS rules exist inside the shadowRoot so the class works
+        let styleTag = shadow.getElementById('miniature-vignette-style') as HTMLStyleElement | null;
+        if (!styleTag) {
+            styleTag = document.createElement('style');
+            styleTag.id = 'miniature-vignette-style';
+            shadow.appendChild(styleTag);
+        }
+
+        styleTag.textContent = `
+            .blur-vignette {
+                position: absolute;
+                background-image: radial-gradient(
+                    circle at center,
+                    rgba(0, 0, 0, 0) 0%,
+                    rgba(0, 0, 0, ${vignetteAlpha}) 85%
+                );
+                inset: 0;
+                object-fit: cover;
+                backdrop-filter: blur(${blurPx}px);
+                -webkit-backdrop-filter: blur(${blurPx}px);
+                mask-image: radial-gradient(
+                    circle at center,
+                    rgba(0, 0, 0, 0) 0%,
+                    rgba(0, 0, 0, 1) 85%
+                );
+                -webkit-mask-image: radial-gradient(
+                    circle at center,
+                    rgba(0, 0, 0, 0) 0%,
+                    rgba(0, 0, 0, 1) 85%
+                );
+                pointer-events: none;
+                border-radius: inherit;
+                z-index: 2;
+            }
+        `;
+
+        const mapContainer = shadow.getElementById('map-container');
+        const haCard = shadow.querySelector('ha-card');
+        const parent = mapContainer ?? haCard;
+        if (!parent) {
+            requestAnimationFrame(() => this._syncMiniatureVignette());
+            return;
+        }
+
+        let vignette = shadow.querySelector('.blur-vignette');
+        if (this._miniatureBlurEnabled && (blurPx > 0 || vignetteAlpha > 0)) {
+            if (!vignette) {
+                vignette = document.createElement('div');
+                vignette.className = 'blur-vignette';
+                vignette.setAttribute('id', 'miniature-blur-vignette');
+                parent.appendChild(vignette);
+            }
+        } else {
+            vignette?.remove();
+        }
+    }
+
+    /**
+     * Inject battery-above-arc CSS rules and toggle the ha-card class
+     * inside the card's Shadow DOM. Same injection pattern as _syncMiniatureVignette.
+     */
+    private _syncShadowDOMOverrides(): void {
+        if (!this._cardElement) return;
+        const shadow = this._cardElement.shadowRoot;
+        if (!shadow) {
+            requestAnimationFrame(() => this._syncShadowDOMOverrides());
+            return;
+        }
+
+        // 1. Ensure the override <style> exists inside the shadow root
+        let overrideStyle = shadow.getElementById('sandbox-override-style') as HTMLStyleElement | null;
+        if (!overrideStyle) {
+            overrideStyle = document.createElement('style');
+            overrideStyle.id = 'sandbox-override-style';
+            shadow.appendChild(overrideStyle);
+        }
+        overrideStyle.textContent = `
+            /* battery-above-arc: elevate energy pills/chips above the solar arc (z 11) and sun disc (z 12). */
+            ha-card.battery-above-arc .pv-pct-label,
+            ha-card.battery-above-arc .battery-pct-label,
+            ha-card.battery-above-arc .grid-label,
+            ha-card.battery-above-arc .group-label,
+            ha-card.battery-above-arc .home-pill,
+            ha-card.battery-above-arc .home-ring
+            {
+                z-index: 13;
+            }
+            ha-card.battery-above-arc .helios-corner-chips
+            {
+                z-index: 13;
+            }
+            ha-card.battery-above-arc .pv-home-leader-svg,
+            ha-card.battery-above-arc .battery-leader-svg,
+            ha-card.battery-above-arc .grid-leader-svg,
+            ha-card.battery-above-arc .group-leader-svg
+            {
+                z-index: 12;
+            }
+        `;
+
+        // 2. Toggle the battery-above-arc class on <ha-card>
+        const haCard = shadow.querySelector('ha-card');
+        if (haCard) {
+            const enabled = this._config['battery-above-arc' as keyof HeliosConfig] === true;
+            haCard.classList.toggle('battery-above-arc', enabled);
+        } else {
+            // ha-card not rendered yet — retry next frame
+            requestAnimationFrame(() => this._syncShadowDOMOverrides());
+        }
+    }
+
+    private _applyConfig(newConfig: HeliosConfig): void {
+        this._config = { ...newConfig };
+        if (this._cardElement) {
+            this._cardElement.setConfig(this._config);
+
+            // arc-zoom and battery-above-arc are NOT in the original VISUAL_CONFIG_KEYS,
+            // so setConfig alone won't push them to the engine via updateConfig.
+            // Force the call directly on the engine instance (available as _engine on the card).
+            const engine = (this._cardElement as any)._engine as HeliosEngine | undefined;
+            if (engine) {
+                engine.updateConfig(this._config);
+            }
+        }
+        this._saveConfigState();
+        this._syncYamlUI();
+        this._syncMiniatureVignette();
+        this._syncShadowDOMOverrides();
+    }
+
+    private _bindUI(): void {
+        // Tabs
+        const tabs = document.querySelectorAll<HTMLButtonElement>('.sidebar-tab');
+        const panes = document.querySelectorAll<HTMLElement>('.tab-pane');
+        tabs.forEach((tab) => {
+            tab.addEventListener('click', () => {
+                const target = tab.dataset.tab;
+                if (!target) return;
+                tabs.forEach((t) => t.classList.remove('active'));
+                panes.forEach((p) => p.classList.remove('active'));
+                tab.classList.add('active');
+                document.getElementById(`tab-${target}`)?.classList.add('active');
+                this._activeTab = target;
+                this._saveUIState();
+            });
+        });
+
+        // Toggle Sidebar
+        const toggleBtn = document.getElementById('btn-toggle-sidebar');
+        const sidebar = document.getElementById('sandbox-sidebar');
+        toggleBtn?.addEventListener('click', () => {
+            this._sidebarCollapsed = !this._sidebarCollapsed;
+            sidebar?.classList.toggle('collapsed', this._sidebarCollapsed);
+            toggleBtn.classList.toggle('collapsed', this._sidebarCollapsed);
+            toggleBtn.textContent = this._sidebarCollapsed ? '◀' : '▶';
+            this._saveUIState();
+        });
+
+        // Dark / Light theme toggle
+        const btnTheme = document.getElementById('btn-theme-toggle');
+        btnTheme?.addEventListener('click', () => {
+            const isDark = !this._hassManager.darkMode;
+            this._hassManager.setDarkMode(isDark);
+            document.body.classList.toggle('light-theme', !isDark);
+            if (btnTheme) {
+                btnTheme.innerHTML = isDark
+                    ? '<svg class="sb-icon" viewBox="0 0 24 24"><path d="M12 3a6 6 0 0 0 9 9 9 9 0 1 1-9-9Z"/></svg><span>Sombre</span>'
+                    : '<svg class="sb-icon" viewBox="0 0 24 24"><circle cx="12" cy="12" r="4"/><path d="M12 2v2"/><path d="M12 20v2"/><path d="m4.93 4.93 1.41 1.41"/><path d="m17.66 17.66 1.41 1.41"/><path d="M2 12h2"/><path d="M20 12h2"/><path d="m6.34 17.66-1.41 1.41"/><path d="m19.07 4.93-1.41 1.41"/></svg><span>Clair</span>';
+            }
+            this._saveUIState();
+        });
+
+        // Viewport switcher
+        const frame = document.getElementById('card-frame');
+        document.querySelectorAll<HTMLButtonElement>('.viewport-btn').forEach((btn) => {
+            btn.addEventListener('click', () => {
+                document.querySelectorAll('.viewport-btn').forEach((b) => b.classList.remove('active'));
+                btn.classList.add('active');
+                const vp = btn.dataset.viewport;
+                frame?.classList.remove('viewport-desktop', 'viewport-tablet', 'viewport-mobile');
+                if (vp) {
+                    frame?.classList.add(`viewport-${vp}`);
+                    this._activeViewport = vp;
+                    this._saveUIState();
+                }
+            });
+        });
+
+        // Reset cache button
+        document.getElementById('btn-reset-cache')?.addEventListener('click', () => {
+            window.dispatchEvent(new CustomEvent('helios-data-cache-reset'));
+            alert('Cache réinitialisé !');
+        });
+
+        // Bind Simulator controls
+        this._bindSlider('sim-solar', 'val-solar', (v) => {
+            this._hassManager.updateSimState({ solarPower: v });
+            this._saveSimState();
+        });
+        this._bindSlider('sim-grid', 'val-grid', (v) => {
+            this._hassManager.updateSimState({ gridPower: v });
+            this._saveSimState();
+        });
+        this._bindSlider('sim-battery-power', 'val-battery-power', (v) => {
+            this._hassManager.updateSimState({ batteryPower: v });
+            this._saveSimState();
+        });
+        this._bindSlider('sim-battery-soc', 'val-battery-soc', (v) => {
+            this._hassManager.updateSimState({ batterySoc: v });
+            this._saveSimState();
+        });
+        this._bindSlider('sim-temp', 'val-temp', (v) => {
+            this._hassManager.updateSimState({ temperature: v });
+            this._saveSimState();
+        });
+        this._bindSlider('sim-humidity', 'val-humidity', (v) => {
+            this._hassManager.updateSimState({ humidity: v });
+            this._saveSimState();
+        });
+
+        const weatherSelect = document.getElementById('sim-weather') as HTMLSelectElement;
+        weatherSelect?.addEventListener('change', () => {
+            this._hassManager.updateSimState({ weatherCondition: weatherSelect.value });
+            this._saveSimState();
+        });
+
+        // Presets
+        document.querySelectorAll<HTMLButtonElement>('.preset-btn').forEach((btn) => {
+            btn.addEventListener('click', () => {
+                const p = btn.dataset.preset;
+                this._applyPreset(p);
+                this._saveSimState();
+            });
+        });
+
+        // Bind Config controls
+        this._bindConfigSlider('cfg-radius', 'val-cfg-radius', 'display-radius');
+        this._bindConfigSlider('cfg-bld-count', 'val-cfg-bld-count', 'building-count');
+        this._bindConfigSlider('cfg-bld-opacity', 'val-cfg-bld-opacity', 'building-opacity', (v) => v / 100);
+        this._bindConfigSlider('cfg-shadow-opacity', 'val-cfg-shadow-opacity', 'shadow-opacity', (v) => v / 100);
+        this._bindConfigSlider('cfg-max-power', 'val-cfg-max-power', 'max-expected-power');
+
+        this._bindConfigSwitch('cfg-shadows', 'shadows-enabled');
+        this._bindConfigSwitch('cfg-bld-real-size', 'building-real-size');
+        this._bindConfigSwitch('cfg-weather', 'weather-enabled');
+        this._bindConfigSwitch('cfg-timeline', 'show-timeline');
+        this._bindConfigSwitch('cfg-detail-panel', 'show-detail-panel');
+        this._bindConfigSwitch('cfg-auto-rotate', 'auto-rotate-enabled');
+        this._bindConfigSwitch('cfg-cam-locked', 'camera-locked');
+        this._bindConfigSwitch('cfg-battery-above-arc', 'battery-above-arc');
+
+        const miniatureSwitch = document.getElementById('cfg-miniature-blur') as HTMLInputElement;
+        const miniatureBlurContainer = document.getElementById('cfg-miniature-blur-container');
+        miniatureSwitch?.addEventListener('change', () => {
+            this._miniatureBlurEnabled = miniatureSwitch.checked;
+            if (miniatureBlurContainer) {
+                miniatureBlurContainer.style.display = miniatureSwitch.checked ? 'flex' : 'none';
+            }
+            this._syncMiniatureVignette();
+            this._saveUIState();
+        });
+
+        this._bindSlider('cfg-miniature-blur-level', 'val-cfg-miniature-blur', (val) => {
+            this._miniatureBlurLevel = val;
+            this._syncMiniatureVignette();
+            this._saveUIState();
+        });
+
+        this._bindSlider('cfg-miniature-vignette-opacity', 'val-cfg-miniature-vignette-opacity', (val) => {
+            this._miniatureVignetteOpacity = val;
+            this._syncMiniatureVignette();
+            this._saveUIState();
+        });
+
+        this._bindConfigSlider('cfg-zoom', 'val-cfg-zoom', 'scene-zoom', (v) => parseFloat(v.toFixed(2)));
+        this._bindConfigSlider('cfg-arc-zoom', 'val-cfg-arc-zoom', 'arc-zoom', (v) => parseFloat(v.toFixed(2)));
+
+        const mapModeSelect = document.getElementById('cfg-map-mode') as HTMLSelectElement;
+        mapModeSelect?.addEventListener('change', () => {
+            this._config['map-theme-mode'] = mapModeSelect.value;
+            this._applyConfig(this._config);
+        });
+
+        // Coordinates input
+        const latInput = document.getElementById('cfg-lat') as HTMLInputElement;
+        const lonInput = document.getElementById('cfg-lon') as HTMLInputElement;
+        const applyCoords = () => {
+            const lat = parseFloat(latInput.value);
+            const lon = parseFloat(lonInput.value);
+            if (!isNaN(lat) && !isNaN(lon)) {
+                this._config['home-latitude'] = lat;
+                this._config['home-longitude'] = lon;
+                this._hassManager.updateConfig({ latitude: lat, longitude: lon });
+                this._applyConfig(this._config);
+            }
+        };
+        latInput?.addEventListener('change', applyCoords);
+        lonInput?.addEventListener('change', applyCoords);
+
+        // Geolocation: Current location
+        const btnCurrentLocation = document.getElementById('btn-current-location') as HTMLButtonElement | null;
+        btnCurrentLocation?.addEventListener('click', () => {
+            if (!('geolocation' in navigator)) {
+                alert('La géolocalisation n\'est pas supportée par votre navigateur.');
+                return;
+            }
+            const originalText = btnCurrentLocation.innerHTML;
+            btnCurrentLocation.disabled = true;
+            btnCurrentLocation.innerHTML = '<svg class="sb-icon spin" viewBox="0 0 24 24"><path d="M21 12a9 9 0 1 1-6.219-8.56"/></svg><span>Détection en cours...</span>';
+
+            navigator.geolocation.getCurrentPosition(
+                (pos) => {
+                    btnCurrentLocation.disabled = false;
+                    btnCurrentLocation.innerHTML = originalText;
+                    const lat = parseFloat(pos.coords.latitude.toFixed(5));
+                    const lon = parseFloat(pos.coords.longitude.toFixed(5));
+                    if (latInput) latInput.value = String(lat);
+                    if (lonInput) lonInput.value = String(lon);
+                    applyCoords();
+                },
+                (err) => {
+                    btnCurrentLocation.disabled = false;
+                    btnCurrentLocation.innerHTML = originalText;
+                    let msg = 'Impossible d\'obtenir la position actuelle : ';
+                    switch (err.code) {
+                        case err.PERMISSION_DENIED:
+                            msg += 'Autorisation refusée par l\'utilisateur.';
+                            break;
+                        case err.POSITION_UNAVAILABLE:
+                            msg += 'Position indisponible.';
+                            break;
+                        case err.TIMEOUT:
+                            msg += 'Délai d\'attente dépassé.';
+                            break;
+                        default:
+                            msg += err.message;
+                    }
+                    alert(msg);
+                },
+                {
+                    enableHighAccuracy: true,
+                    timeout: 10000,
+                    maximumAge: 60000,
+                }
+            );
+        });
+
+        // Predefined city locations
+        document.querySelectorAll<HTMLButtonElement>('.city-btn').forEach((btn) => {
+            btn.addEventListener('click', () => {
+                const lat = parseFloat(btn.dataset.lat || '0');
+                const lon = parseFloat(btn.dataset.lon || '0');
+                if (latInput) latInput.value = String(lat);
+                if (lonInput) lonInput.value = String(lon);
+                applyCoords();
+            });
+        });
+
+        // YAML Apply
+        const yamlTextarea = document.getElementById('yaml-editor') as HTMLTextAreaElement;
+        document.getElementById('btn-apply-yaml')?.addEventListener('click', () => {
+            try {
+                const parsed = JSON.parse(yamlTextarea.value);
+                this._applyConfig(parsed);
+                this._updateConfigUI();
+                alert('Configuration appliquée avec succès !');
+            } catch (err) {
+                alert('Erreur de parsing JSON : ' + (err as Error).message);
+            }
+        });
+
+        document.getElementById('btn-reset-yaml')?.addEventListener('click', () => {
+            localStorage.removeItem(STORAGE_KEY_CONFIG);
+            localStorage.removeItem(STORAGE_KEY_SIM);
+            localStorage.removeItem(STORAGE_KEY_UI);
+            this._miniatureBlurEnabled = false;
+            this._miniatureBlurLevel = 10;
+            this._applyConfig(defaultSandboxConfig);
+            this._updateConfigUI();
+            this._syncYamlUI();
+        });
+    }
+
+    private _bindSlider(sliderId: string, valueId: string, onValue: (v: number) => void): void {
+        const slider = document.getElementById(sliderId) as HTMLInputElement;
+        const valueLabel = document.getElementById(valueId);
+        slider?.addEventListener('input', () => {
+            const val = parseFloat(slider.value);
+            if (valueLabel) valueLabel.textContent = slider.value;
+            onValue(val);
+        });
+    }
+
+    private _bindConfigSlider(
+        sliderId: string,
+        valueId: string,
+        key: keyof HeliosConfig,
+        transform: (v: number) => number = (v) => v
+    ): void {
+        const slider = document.getElementById(sliderId) as HTMLInputElement;
+        const valueLabel = document.getElementById(valueId);
+        slider?.addEventListener('input', () => {
+            const val = transform(parseFloat(slider.value));
+            if (valueLabel) valueLabel.textContent = slider.value;
+            this._config[key] = val;
+            this._applyConfig(this._config);
+        });
+    }
+
+    private _bindConfigSwitch(switchId: string, key: keyof HeliosConfig): void {
+        const checkbox = document.getElementById(switchId) as HTMLInputElement;
+        checkbox?.addEventListener('change', () => {
+            this._config[key] = checkbox.checked;
+            this._applyConfig(this._config);
+        });
+    }
+
+    private _applyPreset(name: string | undefined): void {
+        if (!name) return;
+        let partial: Partial<SandboxSimState> = {};
+        switch (name) {
+            case 'noon_summer':
+                partial = {
+                    solarPower: 5600,
+                    gridPower: -2400,
+                    batteryPower: 2200,
+                    batterySoc: 65,
+                    temperature: 31,
+                    humidity: 38,
+                    weatherCondition: 'sunny',
+                };
+                break;
+            case 'night_discharge':
+                partial = {
+                    solarPower: 0,
+                    gridPower: 150,
+                    batteryPower: -1850,
+                    batterySoc: 48,
+                    temperature: 16,
+                    humidity: 75,
+                    weatherCondition: 'clear-night',
+                };
+                break;
+            case 'storm_import':
+                partial = {
+                    solarPower: 180,
+                    gridPower: 3400,
+                    batteryPower: 0,
+                    batterySoc: 22,
+                    temperature: 14,
+                    humidity: 92,
+                    weatherCondition: 'lightning-rainy',
+                };
+                break;
+            case 'winter_snow':
+                partial = {
+                    solarPower: 450,
+                    gridPower: 2800,
+                    batteryPower: -500,
+                    batterySoc: 30,
+                    temperature: -2,
+                    humidity: 88,
+                    weatherCondition: 'snowy',
+                };
+                break;
+        }
+        this._hassManager.updateSimState(partial);
+        this._updateSimUI();
+    }
+
+    private _updateSimUI(): void {
+        const sim = this._hassManager.simState;
+        const setVal = (id: string, val: string | number) => {
+            const el = document.getElementById(id);
+            if (el) el.textContent = String(val);
+        };
+        const setSlider = (id: string, val: number) => {
+            const el = document.getElementById(id) as HTMLInputElement;
+            if (el) el.value = String(val);
+        };
+
+        setSlider('sim-solar', sim.solarPower);
+        setVal('val-solar', sim.solarPower);
+
+        setSlider('sim-grid', sim.gridPower);
+        setVal('val-grid', sim.gridPower);
+
+        setSlider('sim-battery-power', sim.batteryPower);
+        setVal('val-battery-power', sim.batteryPower);
+
+        setSlider('sim-battery-soc', sim.batterySoc);
+        setVal('val-battery-soc', sim.batterySoc);
+
+        setSlider('sim-temp', sim.temperature);
+        setVal('val-temp', sim.temperature);
+
+        setSlider('sim-humidity', sim.humidity);
+        setVal('val-humidity', sim.humidity);
+
+        const weatherSel = document.getElementById('sim-weather') as HTMLSelectElement;
+        if (weatherSel) weatherSel.value = sim.weatherCondition;
+    }
+
+    private _updateConfigUI(): void {
+        const c = this._config;
+        const setCheck = (id: string, val: unknown) => {
+            const el = document.getElementById(id) as HTMLInputElement;
+            if (el) el.checked = val !== false;
+        };
+        const setSlider = (id: string, valId: string, val: number) => {
+            const el = document.getElementById(id) as HTMLInputElement;
+            const lbl = document.getElementById(valId);
+            if (el) el.value = String(val);
+            if (lbl) lbl.textContent = String(val);
+        };
+
+        setSlider('cfg-radius', 'val-cfg-radius', Number(c['display-radius'] ?? 200));
+        setSlider('cfg-bld-count', 'val-cfg-bld-count', Number(c['building-count'] ?? 50));
+        setSlider('cfg-bld-opacity', 'val-cfg-bld-opacity', Math.round(Number(c['building-opacity'] ?? 0.5) * 100));
+        setSlider('cfg-shadow-opacity', 'val-cfg-shadow-opacity', Math.round(Number(c['shadow-opacity'] ?? 0.32) * 100));
+        setSlider('cfg-max-power', 'val-cfg-max-power', Number(c['max-expected-power'] ?? 5000));
+
+        setCheck('cfg-shadows', c['shadows-enabled']);
+        setCheck('cfg-bld-real-size', c['building-real-size']);
+        setCheck('cfg-weather', c['weather-enabled']);
+        setCheck('cfg-timeline', c['show-timeline']);
+        setCheck('cfg-detail-panel', c['show-detail-panel']);
+        setCheck('cfg-auto-rotate', c['auto-rotate-enabled'] === true);
+        setCheck('cfg-cam-locked', c['camera-locked'] === true);
+        setCheck('cfg-battery-above-arc', c['battery-above-arc'] === true);
+        setCheck('cfg-miniature-blur', this._miniatureBlurEnabled);
+
+        const miniatureBlurContainer = document.getElementById('cfg-miniature-blur-container');
+        if (miniatureBlurContainer) {
+            miniatureBlurContainer.style.display = this._miniatureBlurEnabled ? 'flex' : 'none';
+        }
+        setSlider('cfg-miniature-blur-level', 'val-cfg-miniature-blur', this._miniatureBlurLevel);
+        setSlider('cfg-miniature-vignette-opacity', 'val-cfg-miniature-vignette-opacity', this._miniatureVignetteOpacity);
+
+        setSlider('cfg-zoom', 'val-cfg-zoom', Number(c['scene-zoom'] ?? 1));
+        setSlider('cfg-arc-zoom', 'val-cfg-arc-zoom', Number(c['arc-zoom'] ?? 1));
+
+        const mapModeSel = document.getElementById('cfg-map-mode') as HTMLSelectElement;
+        if (mapModeSel) mapModeSel.value = String(c['map-theme-mode'] ?? 'auto');
+
+        const latInput = document.getElementById('cfg-lat') as HTMLInputElement;
+        if (latInput) latInput.value = String(c['home-latitude'] ?? 48.8566);
+
+        const lonInput = document.getElementById('cfg-lon') as HTMLInputElement;
+        if (lonInput) lonInput.value = String(c['home-longitude'] ?? 2.3522);
+    }
+
+    private _syncYamlUI(): void {
+        const area = document.getElementById('yaml-editor') as HTMLTextAreaElement;
+        if (area) {
+            area.value = JSON.stringify(this._config, null, 2);
+        }
+    }
+}
+
+// Bootstrap
+window.addEventListener('DOMContentLoaded', () => {
+    const app = new SandboxApp();
+    app.init();
+});

--- a/sandbox/sandbox.css
+++ b/sandbox/sandbox.css
@@ -1,0 +1,566 @@
+:root {
+    --sb-bg: #0d1117;
+    --sb-surface: #161b22;
+    --sb-surface-hover: #21262d;
+    --sb-border: #30363d;
+    --sb-text: #e6edf3;
+    --sb-text-muted: #8b949e;
+    --sb-primary: #f59e0b;
+    --sb-primary-hover: #d97706;
+    --sb-accent: #3b82f6;
+    --sb-danger: #ef4444;
+    --sb-success: #10b981;
+    --sb-font: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif;
+
+    /* Home Assistant theme tokens emulated for the card and editor */
+    --ha-card-background: #1e2430;
+    --card-background-color: #1e2430;
+    --primary-background-color: #111827;
+    --secondary-background-color: #1f2937;
+    --primary-color: #3b82f6;
+    --accent-color: #f59e0b;
+    --primary-text-color: #f3f4f6;
+    --secondary-text-color: #9ca3af;
+    --disabled-text-color: #6b7280;
+    --divider-color: rgba(255, 255, 255, 0.12);
+    --shadow-color: rgba(0, 0, 0, 0.4);
+    --error-color: #ef4444;
+    --warning-color: #f59e0b;
+    --success-color: #10b981;
+    --ha-card-border-radius: 16px;
+    --ha-border-radius-sm: 4px;
+    --ha-border-radius-md: 8px;
+    --ha-border-width-sm: 1px;
+}
+
+body.light-theme {
+    --sb-bg: #f3f4f6;
+    --sb-surface: #ffffff;
+    --sb-surface-hover: #f9fafb;
+    --sb-border: #e5e7eb;
+    --sb-text: #1f2937;
+    --sb-text-muted: #6b7280;
+
+    /* HA Light theme */
+    --ha-card-background: #ffffff;
+    --card-background-color: #ffffff;
+    --primary-background-color: #f9fafb;
+    --secondary-background-color: #f3f4f6;
+    --primary-color: #2563eb;
+    --primary-text-color: #111827;
+    --secondary-text-color: #4b5563;
+    --disabled-text-color: #9ca3af;
+    --divider-color: rgba(0, 0, 0, 0.1);
+    --shadow-color: rgba(0, 0, 0, 0.15);
+}
+
+* {
+    box-sizing: border-box;
+    margin: 0;
+    padding: 0;
+}
+
+body {
+    font-family: var(--sb-font);
+    background-color: var(--sb-bg);
+    color: var(--sb-text);
+    height: 100vh;
+    overflow: hidden;
+    display: flex;
+    flex-direction: column;
+}
+
+/* Header */
+.sandbox-header {
+    height: 54px;
+    background: var(--sb-surface);
+    border-bottom: 1px solid var(--sb-border);
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    padding: 0 20px;
+    flex-shrink: 0;
+    z-index: 10;
+}
+
+.brand-badge {
+    display: flex;
+    align-items: center;
+    gap: 10px;
+    font-weight: 700;
+    font-size: 17px;
+    letter-spacing: 0.5px;
+}
+
+.brand-icon {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    color: var(--sb-primary);
+}
+
+.brand-icon svg {
+    width: 22px;
+    height: 22px;
+}
+
+.brand-tag {
+    font-size: 11px;
+    text-transform: uppercase;
+    background: rgba(245, 158, 11, 0.15);
+    color: var(--sb-primary);
+    border: 1px solid rgba(245, 158, 11, 0.3);
+    padding: 2px 8px;
+    border-radius: 12px;
+    font-weight: 600;
+}
+
+.header-controls {
+    display: flex;
+    align-items: center;
+    gap: 10px;
+}
+
+.sb-btn {
+    background: var(--sb-surface);
+    border: 1px solid var(--sb-border);
+    color: var(--sb-text);
+    padding: 6px 12px;
+    border-radius: 6px;
+    font-size: 13px;
+    font-weight: 500;
+    cursor: pointer;
+    display: inline-flex;
+    align-items: center;
+    gap: 6px;
+    transition: all 0.15s ease;
+}
+
+.sb-btn:hover {
+    background: var(--sb-surface-hover);
+    border-color: var(--sb-text-muted);
+}
+
+.sb-icon {
+    width: 16px;
+    height: 16px;
+    display: inline-block;
+    vertical-align: middle;
+    stroke: currentColor;
+    fill: none;
+    stroke-width: 2;
+    stroke-linecap: round;
+    stroke-linejoin: round;
+    flex-shrink: 0;
+}
+
+.sb-icon.spin {
+    animation: sb-spin 1s linear infinite;
+}
+
+@keyframes sb-spin {
+    from { transform: rotate(0deg); }
+    to { transform: rotate(360deg); }
+}
+
+.sb-btn.primary {
+    background: var(--sb-primary);
+    border-color: var(--sb-primary);
+    color: #111827;
+    font-weight: 600;
+}
+
+.sb-btn.primary:hover {
+    background: var(--sb-primary-hover);
+}
+
+/* Main Layout */
+.sandbox-body {
+    flex: 1;
+    display: flex;
+    overflow: hidden;
+    position: relative;
+}
+
+/* Card Preview Stage */
+.preview-stage {
+    flex: 1;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+    padding: 24px;
+    background: rgba(255, 255, 255, 0.9);
+    overflow-y: auto;
+    position: relative;
+}
+
+.stage-viewport-bar {
+    position: absolute;
+    top: 16px;
+    display: flex;
+    gap: 6px;
+    background: var(--sb-surface);
+    border: 1px solid var(--sb-border);
+    padding: 4px;
+    border-radius: 8px;
+    z-index: 5;
+}
+
+.viewport-btn {
+    background: transparent;
+    border: none;
+    color: var(--sb-text-muted);
+    font-size: 12px;
+    padding: 4px 10px;
+    border-radius: 4px;
+    cursor: pointer;
+    font-weight: 500;
+    transition: all 0.15s;
+}
+
+.viewport-btn.active, .viewport-btn:hover {
+    background: var(--sb-surface-hover);
+    color: var(--sb-text);
+}
+
+.card-frame {
+    width: 100%;
+    max-width: 820px;
+    min-height: 520px;
+    height: 560px;
+    box-shadow: 0 10px 30px rgba(0, 0, 0, 0.35);
+    border-radius: var(--ha-card-border-radius);
+    transition: max-width 0.3s cubic-bezier(0.4, 0, 0.2, 1);
+    position: relative;
+    overflow: hidden;
+}
+
+.card-frame.viewport-mobile {
+    max-width: 380px;
+}
+
+.card-frame.viewport-tablet {
+    max-width: 600px;
+}
+
+.card-frame.viewport-desktop {
+    max-width: 840px;
+}
+
+/* Sidebar */
+.sandbox-sidebar {
+    width: 440px;
+    background: var(--sb-surface);
+    border-left: 1px solid var(--sb-border);
+    display: flex;
+    flex-direction: column;
+    overflow: hidden;
+    flex-shrink: 0;
+    transition: width 0.25s ease, transform 0.25s ease;
+}
+
+.sandbox-sidebar.collapsed {
+    width: 0;
+    transform: translateX(100%);
+    border-left: none;
+}
+
+.sidebar-tabs {
+    display: flex;
+    border-bottom: 1px solid var(--sb-border);
+    background: rgba(0, 0, 0, 0.1);
+}
+
+.sidebar-tab {
+    flex: 1;
+    padding: 12px 10px;
+    background: transparent;
+    border: none;
+    color: var(--sb-text-muted);
+    font-size: 12px;
+    font-weight: 600;
+    cursor: pointer;
+    border-bottom: 2px solid transparent;
+    transition: all 0.15s;
+    text-align: center;
+    white-space: nowrap;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    gap: 6px;
+}
+
+.sidebar-tab:hover {
+    color: var(--sb-text);
+    background: var(--sb-surface-hover);
+}
+
+.sidebar-tab.active {
+    color: var(--sb-primary);
+    border-bottom-color: var(--sb-primary);
+    background: var(--sb-surface);
+}
+
+.sidebar-content {
+    flex: 1;
+    overflow-y: auto;
+    padding: 18px;
+    display: flex;
+    flex-direction: column;
+    gap: 16px;
+}
+
+.tab-pane {
+    display: none;
+    flex-direction: column;
+    gap: 16px;
+}
+
+.tab-pane.active {
+    display: flex;
+}
+
+/* Section styling */
+.sb-section {
+    background: rgba(255, 255, 255, 0.02);
+    border: 1px solid var(--sb-border);
+    border-radius: 8px;
+    padding: 14px;
+    display: flex;
+    flex-direction: column;
+    gap: 12px;
+}
+
+.sb-section-title {
+    font-size: 12px;
+    font-weight: 700;
+    text-transform: uppercase;
+    letter-spacing: 0.8px;
+    color: var(--sb-primary);
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+}
+
+.sb-section-title > span {
+    display: inline-flex;
+    align-items: center;
+    gap: 7px;
+}
+
+/* Form Controls in Sidebar */
+.sb-field {
+    display: flex;
+    flex-direction: column;
+    gap: 6px;
+}
+
+.sb-field-row {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 12px;
+}
+
+.sb-label {
+    font-size: 13px;
+    color: var(--sb-text);
+    font-weight: 500;
+}
+
+.sb-label-sub {
+    font-size: 11px;
+    color: var(--sb-text-muted);
+}
+
+.sb-value-badge {
+    font-size: 12px;
+    font-variant-numeric: tabular-nums;
+    color: var(--sb-primary);
+    font-weight: 600;
+}
+
+.sb-range {
+    width: 100%;
+    accent-color: var(--sb-primary);
+    cursor: pointer;
+}
+
+.sb-input {
+    background: var(--sb-bg);
+    border: 1px solid var(--sb-border);
+    color: var(--sb-text);
+    padding: 7px 10px;
+    border-radius: 6px;
+    font-size: 13px;
+    font-family: inherit;
+    width: 100%;
+}
+
+.sb-input:focus {
+    outline: none;
+    border-color: var(--sb-primary);
+}
+
+.sb-select {
+    background: var(--sb-bg);
+    border: 1px solid var(--sb-border);
+    color: var(--sb-text);
+    padding: 7px 10px;
+    border-radius: 6px;
+    font-size: 13px;
+    font-family: inherit;
+    cursor: pointer;
+    width: 100%;
+}
+
+.sb-switch {
+    position: relative;
+    display: inline-block;
+    width: 44px;
+    height: 24px;
+    flex-shrink: 0;
+}
+
+.sb-switch input {
+    opacity: 0;
+    width: 0;
+    height: 0;
+}
+
+.sb-slider-switch {
+    position: absolute;
+    cursor: pointer;
+    top: 0;
+    left: 0;
+    right: 0;
+    bottom: 0;
+    background-color: var(--sb-border);
+    transition: .2s;
+    border-radius: 24px;
+}
+
+.sb-slider-switch:before {
+    position: absolute;
+    content: "";
+    height: 18px;
+    width: 18px;
+    left: 3px;
+    bottom: 3px;
+    background-color: white;
+    transition: .2s;
+    border-radius: 50%;
+}
+
+input:checked + .sb-slider-switch {
+    background-color: var(--sb-primary);
+}
+
+input:checked + .sb-slider-switch:before {
+    transform: translateX(20px);
+}
+
+/* Preset buttons */
+.preset-grid {
+    display: grid;
+    grid-template-columns: repeat(2, 1fr);
+    gap: 8px;
+}
+
+.preset-btn {
+    background: var(--sb-bg);
+    border: 1px solid var(--sb-border);
+    color: var(--sb-text);
+    padding: 8px;
+    border-radius: 6px;
+    font-size: 12px;
+    cursor: pointer;
+    text-align: left;
+    transition: all 0.15s;
+    display: flex;
+    flex-direction: column;
+    gap: 2px;
+}
+
+.preset-btn:hover {
+    border-color: var(--sb-primary);
+    background: var(--sb-surface-hover);
+}
+
+.preset-btn strong {
+    font-size: 12px;
+    color: var(--sb-primary);
+    display: inline-flex;
+    align-items: center;
+    gap: 6px;
+}
+
+/* YAML editor textarea */
+.yaml-textarea {
+    width: 100%;
+    height: 380px;
+    background: var(--sb-bg);
+    border: 1px solid var(--sb-border);
+    color: #a5d6ff;
+    font-family: monospace;
+    font-size: 12px;
+    line-height: 1.5;
+    padding: 12px;
+    border-radius: 6px;
+    resize: vertical;
+    white-space: pre;
+}
+
+.yaml-textarea:focus {
+    outline: none;
+    border-color: var(--sb-primary);
+}
+
+/* Toggle sidebar button */
+.toggle-sidebar-btn {
+    position: absolute;
+    right: 440px;
+    top: 16px;
+    z-index: 20;
+    background: var(--sb-surface);
+    border: 1px solid var(--sb-border);
+    color: var(--sb-text);
+    padding: 8px;
+    border-radius: 8px 0 0 8px;
+    cursor: pointer;
+    box-shadow: -2px 4px 10px rgba(0, 0, 0, 0.2);
+    transition: right 0.25s ease;
+}
+
+.toggle-sidebar-btn.collapsed {
+    right: 0;
+    border-radius: 8px 0 0 8px;
+}
+
+/* Miniature / Tilt-shift vignette effect (sandbox experiment) */
+.blur-vignette {
+    position: absolute;
+    background-image: radial-gradient(
+        circle at center,
+        rgba(0, 0, 0, 0) 0%,
+        rgba(0, 0, 0, 0.5) 85%
+    );
+    inset: 0;
+    object-fit: cover;
+    backdrop-filter: blur(10px);
+    -webkit-backdrop-filter: blur(10px);
+    -webkit-mask-image: radial-gradient(
+        circle at center,
+        rgba(0, 0, 0, 0) 0%,
+        rgba(0, 0, 0, 1) 85%
+    );
+    mask-image: radial-gradient(
+        circle at center,
+        rgba(0, 0, 0, 0) 0%,
+        rgba(0, 0, 0, 1) 85%
+    );
+    pointer-events: none;
+    border-radius: inherit;
+    z-index: 2;
+}


### PR DESCRIPTION
Introduce a self-contained developer sandbox under `sandbox/` to test and
preview the Helios custom card locally with simulated Home Assistant states,
without modifying any production files in `src/` or `dist/`.

### What this adds:

1. **Interactive Sandbox Environment (`sandbox/`)**:
   - `sandbox/index.html`: Responsive preview stage (Desktop, Tablet, Mobile)
     with collapsible sidebar controls.
   - `sandbox/sandbox.css`: Theme-aware styling (dark / light toggle).
   - `sandbox/mock-hass.ts`: Realistic HassMock state manager simulating solar PV,
     battery SoC/power, grid import/export, and weather conditions.
   - `sandbox/sandbox-app.ts`: Orchestrator with Card Settings, Live Simulation,
     and YAML editor tabs.

2. **Experimental Prototype Overrides (Non-intrusive)**:
   All features are implemented as runtime overrides in `sandbox-app.ts`
   leaving `src/` and `dist/` 100% untouched:
   - `arc-zoom`: Dynamic scaling of the sun/moon arc radius ([0.25, 2.0]).
   - Continuous `scene-zoom`: Smooth continuous zoom ([0.25, 2.0]).
   - `battery-above-arc`: Shadow DOM CSS elevation of chips/pills over the 3D arc.
   - Miniature tilt-shift / vignette overlay.
   - `sandbox/git-changes.patch`: Reference patch showing direct `src/` implementation.

### How to test:
1. Run `npm run dev`
2. Open `http://localhost:5173/sandbox/`